### PR TITLE
Implement Simple Build Harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+Makefile.env
+bin/docker-*

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,51 @@
+MAKEFILE_PATH := $(strip $(MAKEFILE_LIST))
+MAKEFILE_DIR := $(shell dirname "$(MAKEFILE_PATH)")
+SELF = make -f $(MAKEFILE_PATH)
+
+define print
+	@echo "$@: $1"
+endef
+
+# Ensures that a variable is defined
+define assert
+  @[ -n "$$$1" ] || (echo "$(1) not defined in $(@)"; exit 1)
+endef
+
+# Setup the docker run-time environment
+ifeq ($(CIRCLECI),true)
+  include $(MAKEFILE_DIR)/modules/Makefile.circleci
+else
+  include $(MAKEFILE_DIR)/modules/Makefile.docker-machine
+endif
+
+# Include the docker-specific targets
+include $(MAKEFILE_DIR)/modules/Makefile.docker
+
+.PHONY : help env deps
+
+.DEFAULT_GOAL := help
+
+## Configure all dependencies
+deps:
+	@[ -d $(MAKEFILE_DIR)/bin ] || mkdir -p $(MAKEFILE_DIR)/bin/
+	@[ -z "$(DEPS_TARGETS)" ] || $(SELF) $(DEPS_TARGETS)
+
+# (private) include environment
+env: deps
+	$(eval -include $(MAKEFILE_PATH).env)
+
+## This help screen
+help:
+	@printf "Available targets:\n\n"
+	@awk '/^[a-zA-Z\-\_0-9%:\\]+:/ { \
+	  helpMessage = match(lastLine, /^## (.*)/); \
+	  if (helpMessage) { \
+	    helpCommand = $$1; \
+	    helpMessage = substr(lastLine, RSTART + 3, RLENGTH); \
+      gsub("\\\\", "", helpCommand); \
+      gsub(":$$", "", helpCommand); \
+	    printf "  %-25s %s\n", helpCommand, helpMessage; \
+	  } \
+	} \
+	{ lastLine = $$0 }' $(MAKEFILE_LIST)
+	@printf "\n"

--- a/Makefile.shim
+++ b/Makefile.shim
@@ -1,0 +1,18 @@
+# This `Makefile` is intended to be included into other projects for the purpose of adding `Docker` capabilities
+# Include this file by adding `-include ../build-harness/Makefile.shim`
+
+BUILD_HARNESS_MAKEFILE ?= $(BUILD_HARNESS_PATH)/Makefile
+
+## Call docker targets
+docker\:%:
+	@make --no-print-directory -f "$(BUILD_HARNESS_MAKEFILE)" $@
+
+## Call docker machine targets
+machine\:%:
+	@make --no-print-directory -f "$(BUILD_HARNESS_MAKEFILE)" $@
+
+## Call CircleCI targets
+circle\:%:
+	@make --no-print-directory -f "$(BUILD_HARNESS_MAKEFILE)" $@
+
+

--- a/README.md
+++ b/README.md
@@ -1,2 +1,92 @@
-# simple-docker-harness
-Docker Harness to facilitate interaction with docker with Docker Machine and CircleCI (public)
+# Build Harness
+
+Facilitate building and releasing docker containers
+
+## General
+
+Run `make help` to get a list of available build targets
+
+```
+# Available targets
+
+  deps                      Configure all dependencies
+  help                      This help screen
+  machine:deps              Setup dependencies for docker-machine
+  machine:info              Docker Machine Info
+  machine:recreate          Recreate the docker machine
+  machine:create            Create docker machine for environment
+  machine:destroy           Destroy docker machine for environment
+  machine:start             Start docker machine for environment
+  machine:stop              Stop docker machine for environment
+  machine:restart           Restart docker machine for environment
+  docker:build              Build a docker image
+  docker:push               Push image to Docker Hub
+  docker:pull               Pull docker image from Docker Hub
+  docker:tag                Tag the last built image with `DOCKER_TAG`
+  docker:clean              Remove existing docker images
+  docker:run                Test drive the image
+  docker:shell              Run the container and start a shell
+  docker:attach             Attach to the running container
+  docker:login              Login to docker registry
+  docker:export             Export docker images to file
+  docker:import             Import docker images from file
+
+# Targets Available on CircleCI
+
+  circle:deps               Install CircleCI deps
+  circle:tag                Tag and push to registry (CircleCI)
+  circle:release            Tag and push official release to registry (CircleCI)
+```
+
+## Using Build Harness in other repositories
+
+1. Create a `Makefile` in in the project (if one does not already exist).
+1. Add the following snippet near the top of the project's `Makefile`
+
+*Snippet*:
+```
+SHELL = /bin/bash
+export BUILD_HARNESS_PATH ?= $(shell until [ -d "build-harness" ] || [ "`pwd`" == '/' ]; do cd ..; done; pwd)/build-harness/
+include $(BUILD_HARNESS_PATH)/Makefile.shim
+```
+
+The default `BUILD_HARNESS_PATH` resolves to the first directory we can find by traversing up the tree until we find one named `build-harness`. e.g. We can override this behavior by setting `BUILD_HARNESS_PATH=/opt/build-harness`
+
+Because we use a conditional assignment on the `BUILD_HARNESS_PATH`, it can always be overriden in a user's `~/.profile|~/.bashrc|~/.bash_profile` to the exact location.
+
+**IMPORTANT** it's highly advised not to change the logic above because it needs to work both locally for development and on CircleCI
+
+## Building images
+
+Before building images, you must create your docker machine and initialize dependencies.
+
+    make machine:create deps
+
+Then build the image
+
+    make docker:build
+
+You can chain targets together as well or even override environment settings, like this:
+
+    make docker:build docker:tag docker:push DOCKER_TAG=foobar
+
+## CircleCI Integration
+
+Here's a minimal example of what is needed for CircleCI. Add/merge the following to your projects `circle.yml` file.
+```yaml
+machine:
+  pre:
+    - "curl --retry 5 --retry-delay 1 https://raw.githubusercontent.com/sagansystems/build-harness/master/bin/circleci.sh | bash -x -s 1.9.1"
+  services:
+    - "docker"
+test:
+  override:
+    - "make docker:build"
+  post:
+    - "make circle:tag"
+deployment:
+  master:
+    branch: "master"
+    commands:
+      - "make circle:release"
+```

--- a/bin/circleci.sh
+++ b/bin/circleci.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+export DOCKER_VERSION=${1:-1.9.1}
+export BUILD_HARNESS_PROJECT=${2:-build-harness}
+export BUILD_HARNESS_BRANCH=${3:-first}
+export GITHUB_REPO="git@github.com:sagansystems/${BUILD_HARNESS_PROJECT}.git"
+
+cd ~
+git clone -b $BUILD_HARNESS_BRANCH $GITHUB_REPO
+make -C $BUILD_HARNESS_PROJECT deps circle:deps
+

--- a/modules/Makefile.circleci
+++ b/modules/Makefile.circleci
@@ -1,0 +1,32 @@
+DOCKER_DOWNLOAD_URL = https://s3-external-1.amazonaws.com/circle-downloads/docker-$(DOCKER_VERSION)-circleci
+DOCKER_CMD = /usr/bin/docker
+
+BUILD ?= $(CIRCLE_BRANCH)-$(CIRCLE_BUILD_NUM)
+COMMIT ?= $(CIRCLE_SHA1)
+RELEASE ?= release-$(shell date -u +'%Y%m%d%H%M%SZ')
+DOCKER_BUILD_OPTS += --build-arg build=$(BUILD) --build-arg commit=$(COMMIT) 
+
+.PHONY : circle\:tag circle\:release circle\:deps
+
+## Install CircleCI deps
+circle\:deps:
+	@echo "INFO: Installing Docker $(DOCKER_VERSION)"
+	@sudo curl -s -o $(DOCKER_CMD) $(DOCKER_DOWNLOAD_URL)
+	@sudo chmod 755 $(DOCKER_CMD)
+
+## Tag and push to registry (CircleCI)
+circle\:tag:
+	@$(call assert,CIRCLE_BRANCH)
+	@$(call assert,CIRCLE_BUILD_NUM)
+	@$(SELF) docker:login
+	@echo "INFO: Tagging $(CIRCLE_BRANCH)"
+	@$(SELF) DOCKER_TAG=$(CIRCLE_BRANCH) docker:tag docker:push
+	@echo "INFO: Releasing $(CIRCLE_BRANCH)-$(CIRCLE_BUILD_NUM)"
+	@$(SELF) DOCKER_TAG=$(CIRCLE_BRANCH)-$(CIRCLE_BUILD_NUM) docker:tag docker:push
+
+## Tag and push official release to registry (CircleCI)
+circle\:release:
+	@$(call assert,RELEASE)
+	@$(SELF) docker:login
+	@echo "INFO: Tagging $(RELEASE)"
+	@$(SELF) DOCKER_TAG=$(RELEASE) docker:tag docker:push

--- a/modules/Makefile.docker
+++ b/modules/Makefile.docker
@@ -1,0 +1,136 @@
+
+# Jot is for OSX, and shuf is for Linux
+RANDOM_PORT ?= $(shell jot -r 1  2000 65000 || shuf -i 2000-65000 -n 1)
+
+LOCAL_OS ?= $(shell uname -s)
+LOCAL_ARCH ?= $(shell uname -m)
+
+DOCKER_REGISTRY := index.docker.io
+DOCKER_NAMESPACE ?= sagan
+DOCKER_VERSION ?= 1.10.1
+
+DOCKER_CLIENT_VERSION = `$(DOCKER_CMD) version --format={{.Client.Version}} 2>/dev/null`
+DOCKER_SERVER_VERSION = `$(DOCKER_CMD) version --format={{.Server.Version}} 2>/dev/null`
+
+
+# These vars are are used by the `login` target.
+DOCKER_EMAIL ?=
+DOCKER_USER ?=
+DOCKER_PASS ?=
+
+# The image we're building - defaults to the current directory name
+DOCKER_IMAGE ?= $(subst -docker,,$(shell basename "`pwd`"))
+
+# Tag used when building image
+DOCKER_BUILD_TAG ?= dev
+
+# Tag used when tagging image built with DOCKER_BUILD_TAG and tag pushed to repo
+DOCKER_TAG ?= $(DOCKER_BUILD_TAG)
+
+# Docker Repository to push image to on registry
+DOCKER_REPOSITORY ?= $(DOCKER_NAMESPACE)/$(DOCKER_IMAGE)
+
+# Complete URI to docker image
+DOCKER_URI ?= $(DOCKER_REGISTRY)/$(DOCKER_REPOSITORY):$(DOCKER_TAG)
+
+# Filename used for docker export
+DOCKER_EXPORT ?= $(DOCKER_NAMESPACE)-$(DOCKER_IMAGE)-$(DOCKER_TAG)-export.tar
+
+# Path to build (where the Dockerfile is located)
+DOCKER_BUILD_PATH ?= .
+
+# The default dockerfile name used
+DOCKER_FILE := Dockerfile
+
+# If attempting to start the container, this name will be used
+DOCKER_CONTAINER_NAME ?= test_$(DOCKER_IMAGE)
+
+DOCKER_BIND_PORT ?= $(RANDOM_PORT):80
+DOCKER_SHELL ?= /bin/bash
+
+# Docker client 
+DOCKER_CMD ?= $(MAKEFILE_DIR)/bin/docker-$(DOCKER_VERSION)
+
+# Arguments passed to "docker build"
+DOCKER_BUILD_OPTS ?=
+
+.PHONY : docker\:build docker\:push docker\:pull docker\:clean docker\:run docker\:shell docker\:attach docker\:update docker\:start docker\:stop docker\:rm docker\:logs 
+
+docker\:info:
+	@echo 'DOCKER_IMAGE=$(DOCKER_IMAGE)'
+	@echo 'DOCKER_BUILD_TAG=$(DOCKER_BUILD_TAG)'
+	@echo 'DOCKER_CONTAINER_NAME=$(DOCKER_CONTAINER_NAME)'
+	@echo 'DOCKER_CMD=$(DOCKER_CMD)'
+	@echo 'DOCKER_BUILD_OPTS=$(DOCKER_BUILD_OPTS)'
+	@echo 'DOCKER_NAMESPACE=$(DOCKER_NAMESPACE)'
+	@echo 'DOCKER_IMAGE=$(DOCKER_IMAGE)'
+	@echo 'DOCKER_TAG=$(DOCKER_TAG)'
+	@echo 'DOCKER_FILE=$(DOCKER_FILE)'
+	@echo 'DOCKER_REGISTRY=$(DOCKER_REGISTRY)'
+	@echo 'DOCKER_VERSION=$(DOCKER_VERSION)'
+	@echo 'DOCKER_URI=$(DOCKER_URI)'
+
+## Build a docker image
+docker\:build: env
+	@echo "INFO: Building $(DOCKER_IMAGE):$(DOCKER_BUILD_TAG) using $(DOCKER_BUILD_PATH)/$(DOCKER_FILE) on docker $(DOCKER_SERVER_VERSION)"
+	@cd $(DOCKER_BUILD_PATH) && $(DOCKER_CMD) build $(DOCKER_BUILD_OPTS) -t "$(DOCKER_REPOSITORY):$(DOCKER_BUILD_TAG)" -f $(DOCKER_FILE) .
+
+## Push image to Docker Hub
+docker\:push: env
+	@echo "INFO: Pushing $(DOCKER_URI)"
+	@until $(DOCKER_CMD) push "$(DOCKER_URI)"; do sleep 1; done
+
+## Pull docker image from Docker Hub
+docker\:pull: env
+	@echo "INFO: Pulling $(DOCKER_URI)"
+	@$(DOCKER_CMD) pull "$(DOCKER_URI)"
+
+## Tag the last built image with `DOCKER_TAG`
+docker\:tag: env
+	@echo INFO: Tagging $(DOCKER_REPOSITORY):$(DOCKER_BUILD_TAG) as $(DOCKER_URI)
+	@$(DOCKER_CMD) tag "$(DOCKER_REPOSITORY):$(DOCKER_BUILD_TAG)" "$(DOCKER_URI)"
+
+## Remove existing docker images
+docker\:clean: env
+	@echo INFO: Clean $(DOCKER_REPOSITORY):$(DOCKER_BUILD_TAG), $(DOCKER_URI)
+	@$(DOCKER_CMD) rmi -f "$(DOCKER_REPOSITORY):$(DOCKER_BUILD_TAG)"
+	@$(DOCKER_CMD) rmi -f "$(DOCKER_URI)"
+	$(eval DOCKER_BUILD_OPTS += --no-cache=true)
+
+## Test drive the image
+docker\:run: env
+	@echo "INFO: Running $(DOCKER_REPOSITORY):$(DOCKER_BUILD_TAG) as $(DOCKER_CONTAINER_NAME)"
+	@$(DOCKER_CMD) run --name "$(DOCKER_CONTAINER_NAME)" --rm -p "$(DOCKER_BIND_PORT)" -t -i "$(DOCKER_REPOSITORY):$(DOCKER_BUILD_TAG)"
+
+## Run the container and start a shell
+docker\:shell: env
+	@echo INFO: Starting shell in $(DOCKER_IMAGE) as $(DOCKER_CONTAINER_NAME) with $(DOCKER_BIND_PORT)
+	@$(DOCKER_CMD) run --name "$(DOCKER_CONTAINER_NAME)" --rm -p "$(DOCKER_BIND_PORT)" -t -i --volume "$(shell pwd):/opt" --entrypoint="$(DOCKER_SHELL)"  "$(DOCKER_REPOSITORY):$(DOCKER_BUILD_TAG)" -c $(DOCKER_SHELL)
+
+## Attach to the running container
+docker\:attach: env
+	@echo INFO: Attaching to $(DOCKER_CONTAINER_NAME)
+	@$(DOCKER_CMD) exec -i -t  "$(DOCKER_CONTAINER_NAME)" $(DOCKER_SHELL)
+
+## Login to docker registry
+docker\:login: env
+	@$(call assert,DOCKER_EMAIL)
+	@$(call assert,DOCKER_USER)
+	@$(call assert,DOCKER_PASS)
+	@echo "INFO: Logging in as $(DOCKER_USER)"
+	@$(DOCKER_CMD) login -e $(DOCKER_EMAIL) -u $(DOCKER_USER) -p $(DOCKER_PASS)
+
+## Export docker images to file
+docker\:export:
+	@$(call assert,DOCKER_IMAGE)
+	@$(call assert,DOCKER_TAG)
+	@$(call assert,DOCKER_EXPORT)
+	@echo INFO: Exporting $(DOCKER_NAMESPACE)/$(DOCKER_IMAGE):$(DOCKER_TAG) to $(DOCKER_EXPORT)
+	@docker save $(DOCKER_NAMESPACE)/$(DOCKER_IMAGE):$(DOCKER_TAG) > $(DOCKER_EXPORT)
+
+## Import docker images from file
+docker\:import:
+	@$(call assert,DOCKER_EXPORT)
+	@echo INFO: Importing $(DOCKER_EXPORT)
+	@docker load -i $(DOCKER_EXPORT)
+

--- a/modules/Makefile.docker-machine
+++ b/modules/Makefile.docker-machine
@@ -1,0 +1,63 @@
+DOCKER_MACHINE_NAME ?= gladly
+DOCKER_DOWNLOAD_URL ?= https://get.docker.com/builds/$(LOCAL_OS)/$(LOCAL_ARCH)/docker-$(DOCKER_VERSION)
+DOCKER_ISO ?= https://github.com/boot2docker/boot2docker/releases/download/v$(DOCKER_VERSION)/boot2docker.iso
+DOCKER_MACHINE_MEMORY ?= 4096
+DOCKER_MACHINE_DISK ?= 50000
+
+export DOCKER_MACHINE_NAME
+
+DEPS_TARGETS += machine:deps
+
+.PHONY : machine\:deps machine\:info machine\:recreate machine\:create machine\:destroy machine\:start machine\:stop machine\:restart machine\:deps
+
+## Setup dependencies for docker-machine
+machine\:deps:
+	@[ -x $(DOCKER_CMD) ] || (curl -s -o $(DOCKER_CMD) $(DOCKER_DOWNLOAD_URL) && chmod 755 $(DOCKER_CMD))
+	@(docker-machine status $(DOCKER_MACHINE_NAME) 2>&1 | grep -q "does not exist"; [ $$? -ne 0 ]) || $(SELF) machine:create
+	@(docker-machine status $(DOCKER_MACHINE_NAME) 2>&1 | grep -q "^Running") || $(SELF) machine:start
+	@docker-machine env $(DOCKER_MACHINE_NAME) | tr -d '"' > "$(MAKEFILE_PATH).env"
+	$(eval -include $(MAKEFILE_PATH).env)
+	@$(call assert,DOCKER_HOST)
+	@$(call assert,DOCKER_CERT_PATH)
+	@$(DOCKER_CMD) version 2>&1 >/dev/null | grep 'Error response from daemon'; [ $$? -ne 0 ]
+
+## Docker Machine Info
+machine\:info:
+	@echo 'DOCKER_MACHINE_NAME=$(DOCKER_MACHINE_NAME)'
+	@echo 'DOCKER_DOWNLOAD_URL=$(DOCKER_DOWNLOAD_URL)'
+	@echo 'DOCKER_HOST=$(DOCKER_HOST)'
+	@echo 'DOCKER_CERT_PATH=$(DOCKER_CERT_PATH)'
+	@echo 'DOCKER_MACHINE_MEMORY=$(DOCKER_MACHINE_MEMORY)'
+	@echo 'DOCKER_MACHINE_DISK=$(DOCKER_MACHINE_DISK)'
+
+## Recreate the docker machine
+machine\:recreate:
+	@$(SELF) machine:destroy machine:create
+
+## Create docker machine for environment
+machine\:create:
+	$(call assert,DOCKER_MACHINE_NAME)
+	@echo "INFO: Creating '$(DOCKER_MACHINE_NAME)' docker machine"
+	@docker-machine create --driver virtualbox --virtualbox-memory $(DOCKER_MACHINE_MEMORY) --virtualbox-disk-size=$(DOCKER_MACHINE_DISK) --virtualbox-boot2docker-url=$(DOCKER_ISO) $(DOCKER_MACHINE_NAME)
+
+## Destroy docker machine for environment
+machine\:destroy:
+	$(call assert,DOCKER_MACHINE_NAME)
+	@echo "INFO: Destroying '$(DOCKER_MACHINE_NAME)' docker machine"
+	@docker-machine rm $(DOCKER_MACHINE_NAME)
+
+## Start docker machine for environment
+machine\:start:
+	$(call assert,DOCKER_MACHINE_NAME)
+	@echo "INFO: Starting '$(DOCKER_MACHINE_NAME)' docker machine"
+	@docker-machine start $(DOCKER_MACHINE_NAME)
+
+## Stop docker machine for environment
+machine\:stop:
+	$(call assert,DOCKER_MACHINE_NAME)
+	@echo "INFO: Stopping '$(DOCKER_MACHINE_NAME)' docker machine"
+	@docker-machine stop $(DOCKER_MACHINE_NAME)
+
+## Restart docker machine for environment
+machine\:restart:
+	@$(SELF) machine:stop machine:start


### PR DESCRIPTION
## What
* Make build-harness work with CircleCI
* Make build-harness work with Docker Machine
* Present a consistent interface for either run-time
 
![image](https://cloud.githubusercontent.com/assets/52489/13756157/c3f736a2-e9db-11e5-8327-6b3a97911ada.png)

Or maybe you just want to build a branch and push it?
![image](https://cloud.githubusercontent.com/assets/52489/13757104/265a0b90-e9e0-11e5-9e9e-051dc6a277a2.png)


## Why
* Nearly every service by Sagan will be deployed via docker
* The process of building, tagging, pushing and releasing images should be the same
* It should be very easy to update `circle.yml` without remembering a lot of syntax

## Who
@darend 
cc: @christopherriley 