### PR TITLE
Improve ux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,12 @@
+PACKAGE_NAME := build-harness
 MAKEFILE_PATH := $(strip $(MAKEFILE_LIST))
 MAKEFILE_DIR := $(shell dirname "$(MAKEFILE_PATH)")
 SELF = make -f $(MAKEFILE_PATH)
+
+# Formatting codes
+green = \x1b[32;01m$1\x1b[0m
+yellow = \x1b[33;01m$1\x1b[0m
+red = \x1b[33;31m$1\x1b[0m
 
 define print
 	@echo "$@: $1"
@@ -21,11 +27,14 @@ endif
 # Include the docker-specific targets
 include $(MAKEFILE_DIR)/modules/Makefile.docker
 
+# Include help targets
+include $(MAKEFILE_DIR)/modules/Makefile.help
+
 .PHONY : help env deps
 
 .DEFAULT_GOAL := help
 
-## Configure all dependencies
+# (private) Configure all dependencies
 deps:
 	@[ -d $(MAKEFILE_DIR)/bin ] || mkdir -p $(MAKEFILE_DIR)/bin/
 	@[ -z "$(DEPS_TARGETS)" ] || $(SELF) $(DEPS_TARGETS)
@@ -34,18 +43,3 @@ deps:
 env: deps
 	$(eval -include $(MAKEFILE_PATH).env)
 
-## This help screen
-help:
-	@printf "Available targets:\n\n"
-	@awk '/^[a-zA-Z\-\_0-9%:\\]+:/ { \
-	  helpMessage = match(lastLine, /^## (.*)/); \
-	  if (helpMessage) { \
-	    helpCommand = $$1; \
-	    helpMessage = substr(lastLine, RSTART + 3, RLENGTH); \
-      gsub("\\\\", "", helpCommand); \
-      gsub(":$$", "", helpCommand); \
-	    printf "  %-25s %s\n", helpCommand, helpMessage; \
-	  } \
-	} \
-	{ lastLine = $$0 }' $(MAKEFILE_LIST)
-	@printf "\n"

--- a/Makefile.shim
+++ b/Makefile.shim
@@ -1,18 +1,15 @@
 # This `Makefile` is intended to be included into other projects for the purpose of adding `Docker` capabilities
-# Include this file by adding `-include ../build-harness/Makefile.shim`
-
+PACKAGE_NAME = $(shell basename `pwd`)
 BUILD_HARNESS_MAKEFILE ?= $(BUILD_HARNESS_PATH)/Makefile
+BUILD_NAMESPACES=docker\:% machine\:% circle\:% 
+MAKEFILE_LIST += $(BUILD_HARNESS_MAKEFILE)
 
-## Call docker targets
-docker\:%:
+include $(BUILD_HARNESS_PATH)/modules/Makefile.help
+
+# Expose various namespaces from build-harness
+$(BUILD_NAMESPACES):
 	@make --no-print-directory -f "$(BUILD_HARNESS_MAKEFILE)" $@
 
-## Call docker machine targets
-machine\:%:
+# Expose help target from build-harness (double (::) allows a target to be extended)
+help::
 	@make --no-print-directory -f "$(BUILD_HARNESS_MAKEFILE)" $@
-
-## Call CircleCI targets
-circle\:%:
-	@make --no-print-directory -f "$(BUILD_HARNESS_MAKEFILE)" $@
-
-

--- a/modules/Makefile.docker
+++ b/modules/Makefile.docker
@@ -57,18 +57,20 @@ DOCKER_BUILD_OPTS ?=
 .PHONY : docker\:build docker\:push docker\:pull docker\:clean docker\:run docker\:shell docker\:attach docker\:update docker\:start docker\:stop docker\:rm docker\:logs 
 
 docker\:info:
-	@echo 'DOCKER_IMAGE=$(DOCKER_IMAGE)'
-	@echo 'DOCKER_BUILD_TAG=$(DOCKER_BUILD_TAG)'
-	@echo 'DOCKER_CONTAINER_NAME=$(DOCKER_CONTAINER_NAME)'
-	@echo 'DOCKER_CMD=$(DOCKER_CMD)'
-	@echo 'DOCKER_BUILD_OPTS=$(DOCKER_BUILD_OPTS)'
-	@echo 'DOCKER_NAMESPACE=$(DOCKER_NAMESPACE)'
-	@echo 'DOCKER_IMAGE=$(DOCKER_IMAGE)'
-	@echo 'DOCKER_TAG=$(DOCKER_TAG)'
-	@echo 'DOCKER_FILE=$(DOCKER_FILE)'
-	@echo 'DOCKER_REGISTRY=$(DOCKER_REGISTRY)'
-	@echo 'DOCKER_VERSION=$(DOCKER_VERSION)'
-	@echo 'DOCKER_URI=$(DOCKER_URI)'
+	@echo "DOCKER_IMAGE=$(DOCKER_IMAGE)"
+	@echo "DOCKER_BUILD_TAG=$(DOCKER_BUILD_TAG)"
+	@echo "DOCKER_CONTAINER_NAME=$(DOCKER_CONTAINER_NAME)"
+	@echo "DOCKER_CMD=$(DOCKER_CMD)"
+	@echo "DOCKER_BUILD_OPTS=$(DOCKER_BUILD_OPTS)"
+	@echo "DOCKER_NAMESPACE=$(DOCKER_NAMESPACE)"
+	@echo "DOCKER_IMAGE=$(DOCKER_IMAGE)"
+	@echo "DOCKER_TAG=$(DOCKER_TAG)"
+	@echo "DOCKER_FILE=$(DOCKER_FILE)"
+	@echo "DOCKER_REGISTRY=$(DOCKER_REGISTRY)"
+	@echo "DOCKER_VERSION=$(DOCKER_VERSION)"
+	@echo "DOCKER_URI=$(DOCKER_URI)"
+	@echo "DOCKER_CLIENT_VERSION=$(DOCKER_CLIENT_VERSION)"
+	@echo "DOCKER_SERVER_VERSION=$(DOCKER_SERVER_VERSION)"
 
 ## Build a docker image
 docker\:build: env
@@ -84,6 +86,10 @@ docker\:push: env
 docker\:pull: env
 	@echo "INFO: Pulling $(DOCKER_URI)"
 	@$(DOCKER_CMD) pull "$(DOCKER_URI)"
+
+docker\:test:
+	@$(DOCKER_CMD) version 2>&1 >/dev/null | grep 'Error response from daemon'; [ $$? -ne 0 ]
+	@echo "OK"
 
 ## Tag the last built image with `DOCKER_TAG`
 docker\:tag: env

--- a/modules/Makefile.docker-machine
+++ b/modules/Makefile.docker-machine
@@ -16,10 +16,6 @@ machine\:deps:
 	@(docker-machine status $(DOCKER_MACHINE_NAME) 2>&1 | grep -q "does not exist"; [ $$? -ne 0 ]) || $(SELF) machine:create
 	@(docker-machine status $(DOCKER_MACHINE_NAME) 2>&1 | grep -q "^Running") || $(SELF) machine:start
 	@docker-machine env $(DOCKER_MACHINE_NAME) | tr -d '"' > "$(MAKEFILE_PATH).env"
-	$(eval -include $(MAKEFILE_PATH).env)
-	@$(call assert,DOCKER_HOST)
-	@$(call assert,DOCKER_CERT_PATH)
-	@$(DOCKER_CMD) version 2>&1 >/dev/null | grep 'Error response from daemon'; [ $$? -ne 0 ]
 
 ## Docker Machine Info
 machine\:info:

--- a/modules/Makefile.help
+++ b/modules/Makefile.help
@@ -1,0 +1,18 @@
+# Formatting codes
+green = \x1b[32;01m$1\x1b[0m
+
+## This help screen
+help::
+	@printf "\n## $(PACKAGE_NAME) targets:\n\n"
+	@awk '/^[a-zA-Z\-\_0-9%:\\]+:/ { \
+	  helpMessage = match(lastLine, /^## (.*)/); \
+	  if (helpMessage) { \
+	    helpCommand = $$1; \
+	    helpMessage = substr(lastLine, RSTART + 3, RLENGTH); \
+      gsub("\\\\", "", helpCommand); \
+      gsub(":+$$", "", helpCommand); \
+	    printf "  $(call green,%-25s) %s\n", helpCommand, helpMessage; \
+	  } \
+	} \
+	{ lastLine = $$0 }' $(MAKEFILE_LIST)
+	@printf "\n"


### PR DESCRIPTION
## What
* Show help for `build-harness`
* Only show `circle:%` targets if on circle
* Colorize targets
* Solve cold-start problem when `Makefile.env` created for first time
* Output `DOCKER_SERVER_VERSION` and `DOCKER_CLIENT_VERSION`
* Create reusable `help` target with `Makefile.help` module

## Who
@darend 
cc: @yayalice 