### PR TITLE
Fix assertions where variable may not need to be exported but should still be set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,14 @@ define print
 	@echo "$@: $1"
 endef
 
-# Ensures that a variable is defined
+# Ensures that a variable is exported
 define assert
-  @[ -n "$$$1" ] || (echo "$(1) not defined in $(@)"; exit 1)
+  @[ -n "$$$1" ] || (echo "$(1) not exported in $(@)"; exit 1)
+endef
+
+# Ensures that a variable is set
+define assert_set
+  @[ -n "$($1)" ] || (echo "$(1) not set in $(@)"; exit 1)
 endef
 
 # Setup the docker run-time environment

--- a/modules/Makefile.circleci
+++ b/modules/Makefile.circleci
@@ -16,8 +16,8 @@ circle\:deps:
 
 ## Tag and push to registry (CircleCI)
 circle\:tag:
-	@$(call assert,CIRCLE_BRANCH)
-	@$(call assert,CIRCLE_BUILD_NUM)
+	@$(call assert_set,CIRCLE_BRANCH)
+	@$(call assert_set,CIRCLE_BUILD_NUM)
 	@$(SELF) docker:login
 	@echo "INFO: Tagging $(CIRCLE_BRANCH)"
 	@$(SELF) DOCKER_TAG=$(CIRCLE_BRANCH) docker:tag docker:push
@@ -26,7 +26,7 @@ circle\:tag:
 
 ## Tag and push official release to registry (CircleCI)
 circle\:release:
-	@$(call assert,RELEASE)
+	@$(call assert_set,RELEASE)
 	@$(SELF) docker:login
 	@echo "INFO: Tagging $(RELEASE)"
 	@$(SELF) DOCKER_TAG=$(RELEASE) docker:tag docker:push

--- a/modules/Makefile.docker
+++ b/modules/Makefile.docker
@@ -120,23 +120,23 @@ docker\:attach: env
 
 ## Login to docker registry
 docker\:login: env
-	@$(call assert,DOCKER_EMAIL)
-	@$(call assert,DOCKER_USER)
-	@$(call assert,DOCKER_PASS)
+	@$(call assert_set,DOCKER_EMAIL)
+	@$(call assert_set,DOCKER_USER)
+	@$(call assert_set,DOCKER_PASS)
 	@echo "INFO: Logging in as $(DOCKER_USER)"
 	@$(DOCKER_CMD) login -e $(DOCKER_EMAIL) -u $(DOCKER_USER) -p $(DOCKER_PASS)
 
 ## Export docker images to file
 docker\:export:
-	@$(call assert,DOCKER_IMAGE)
-	@$(call assert,DOCKER_TAG)
-	@$(call assert,DOCKER_EXPORT)
+	@$(call assert_set,DOCKER_IMAGE)
+	@$(call assert_set,DOCKER_TAG)
+	@$(call assert_set,DOCKER_EXPORT)
 	@echo INFO: Exporting $(DOCKER_NAMESPACE)/$(DOCKER_IMAGE):$(DOCKER_TAG) to $(DOCKER_EXPORT)
 	@docker save $(DOCKER_NAMESPACE)/$(DOCKER_IMAGE):$(DOCKER_TAG) > $(DOCKER_EXPORT)
 
 ## Import docker images from file
 docker\:import:
-	@$(call assert,DOCKER_EXPORT)
+	@$(call assert_set,DOCKER_EXPORT)
 	@echo INFO: Importing $(DOCKER_EXPORT)
 	@docker load -i $(DOCKER_EXPORT)
 


### PR DESCRIPTION
## What
* define new `assert_set` macro which checks if a variable is set
* update `Makefile.docker` and `Makefile.circle` to use `assert_set` instead of `assert` where applicable

## Why
Some variables need to be exported so that other commands (processes) have access to them, while others do not need to be exported. The previous `assert` macro only checked the former.

## Who
@darend 