### PR TITLE
Integrate kubernetes deployment with build-harness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ PACKAGE_NAME := build-harness
 MAKEFILE_PATH := $(strip $(MAKEFILE_LIST))
 MAKEFILE_DIR := $(shell dirname "$(MAKEFILE_PATH)")
 SELF = make -f $(MAKEFILE_PATH)
+SHELL := /bin/bash
 
 # Formatting codes
 green = \x1b[32;01m$1\x1b[0m
@@ -25,6 +26,8 @@ endef
 # Setup the docker run-time environment
 ifeq ($(CIRCLECI),true)
   include $(MAKEFILE_DIR)/modules/Makefile.circleci
+  include $(MAKEFILE_DIR)/modules/Makefile.kubernetes
+  include $(MAKEFILE_DIR)/modules/datadog/Makefile
 else
   include $(MAKEFILE_DIR)/modules/Makefile.docker-machine
 endif

--- a/Makefile.shim
+++ b/Makefile.shim
@@ -1,7 +1,7 @@
 # This `Makefile` is intended to be included into other projects for the purpose of adding `Docker` capabilities
 PACKAGE_NAME = $(shell basename `pwd`)
 BUILD_HARNESS_MAKEFILE ?= $(BUILD_HARNESS_PATH)/Makefile
-BUILD_NAMESPACES=docker\:% machine\:% circle\:% 
+BUILD_NAMESPACES=docker\:% machine\:% circle\:% kubernetes\:% datadog\:%
 MAKEFILE_LIST += $(BUILD_HARNESS_MAKEFILE)
 
 include $(BUILD_HARNESS_PATH)/modules/Makefile.help

--- a/README.md
+++ b/README.md
@@ -110,10 +110,22 @@ deployment:
     commands:
       - make circle:tag          # Tag and publish using branch and build number
       - make circle:tag-latest   # Tag as latest, only on master
+      - make kubernetes:deploy:  # Deloy to master.gladly.com
+        environment:
+          CLUSTER_NAMESPACE: master 
+          CLUSTER_DOMAIN: gladly.com
+
+  daren:
+    branch: "daren"
+    commands:
+      - make circle:tag          # Tag and publish using branch and build number
+      - make circle:tag-latest   # Tag as latest, only on master
+      - make kubernetes:deploy:
+        environment:
+          CLUSTER_NAMESPACE: daren 
 
   else:
     branch: "/.*/"               # All other branches, tag and publish using branch and build number
     commands:
       - make circle:tag
-
 ```

--- a/bin/circleci.sh
+++ b/bin/circleci.sh
@@ -5,6 +5,11 @@ export BUILD_HARNESS_BRANCH=${3:-master}
 export GITHUB_REPO="git@github.com:sagansystems/${BUILD_HARNESS_PROJECT}.git"
 
 cd ~
+if [ "$BUILD_HARNESS_PROJECT" ] && [ -d "$BUILD_HARNESS_PROJECT" ]; then
+	echo "Removing existing $BUILD_HARNESS_PROJECT"
+  rm -rf "$BUILD_HARNESS_PROJECT"
+fi
+
 git clone -b $BUILD_HARNESS_BRANCH $GITHUB_REPO
 make -C $BUILD_HARNESS_PROJECT deps circle:deps
 

--- a/modules/Makefile.help
+++ b/modules/Makefile.help
@@ -11,7 +11,7 @@ help::
 	    helpMessage = substr(lastLine, RSTART + 3, RLENGTH); \
       gsub("\\\\", "", helpCommand); \
       gsub(":+$$", "", helpCommand); \
-	    printf "  $(call green,%-25s) %s\n", helpCommand, helpMessage; \
+	    printf "  $(call green,%-35s) %s\n", helpCommand, helpMessage; \
 	  } \
 	} \
 	{ lastLine = $$0 }' $(MAKEFILE_LIST)

--- a/modules/Makefile.kubernetes
+++ b/modules/Makefile.kubernetes
@@ -1,0 +1,116 @@
+CLUSTER_NAMESPACE ?= 
+CLUSTER_DOMAIN ?= mertslounge.ca
+CLUSTER_BASTION ?= bastion.$(CLUSTER_NAMESPACE).$(CLUSTER_DOMAIN)
+export CLUSTER_NAMESPACE
+  
+KUBERNETES_APP ?= $(subst -docker,,$(shell basename "`pwd`"))
+KUBERNETES_RESOURCE_PATH ?= ./kubernetes
+export KUBERNETES_APP
+
+# Kubectl specific settings
+KUBECTL ?= /opt/bin/kubectl
+KUBECTL_SCHEMA_CACHE_DIR ?= --schema-cache-dir=.kube/cache
+KUBECTL_SSH_CMD := ssh -A -o 'BatchMode=yes' -o 'LogLevel=error' -o 'StrictHostKeyChecking=no' -o 'UserKnownHostsFile=/dev/null'
+# Optionally define an SSH command to use for tunneling kubectl commands
+KUBECTL_SSH_TUNNEL ?= $(KUBECTL_SSH_USER)@$(CLUSTER_BASTION)
+
+# Serial number optionally used for versioning; select the last 5 characters of unix time (24 character limit to resource names in k8s)
+SERIAL ?= $(shell echo -n $$(date +%s) | tail -c 5)
+export SERIAL
+
+define kubectl_create
+	@echo -e "INFO: Creating $(KUBERNETES_APP) $(1) on cluster $(call yellow,$(CLUSTER_NAMESPACE))..."
+	@envsubst < "$(KUBERNETES_RESOURCE_PATH)/$(KUBERNETES_APP)-$(1).yml" | envsubst | $(KUBECTL_CMD) create $(KUBECTL_SCHEMA_CACHE_DIR) -f -
+endef
+
+define kubectl_delete
+	@echo -e "INFO: Deleteting $(KUBERNETES_APP) $(1) on cluster $(call yellow,$(CLUSTER_NAMESPACE))..."
+	@envsubst < "$(KUBERNETES_RESOURCE_PATH)/$(KUBERNETES_APP)-$(1).yml" | envsubst | $(KUBECTL_CMD) delete --ignore-not-found=true -f -
+endef
+
+ifeq ($(CIRCLECI),true)
+  KUBECTL_SSH_CMD += -i '$(HOME)/.ssh/id_circleci_github'
+  KUBECTL_SSH_USER ?= saganbot
+  CLUSTER_NAMESPACE ?= $(CIRCLE_BRANCH)
+endif
+
+ifeq ($(strip $(KUBECTL_SSH_USER)),)
+  # Guess their github username
+	KUBECTL_SSH_USER = $(shell ssh git@github.com 2>&1 | grep 'successfully authenticated' | cut -d' ' -f2 | cut -d'!' -f1)
+endif
+
+# Add the SSH endpoint to the command; everything after the host is expected to be a remote command
+KUBECTL_SSH_CMD += $(KUBECTL_SSH_TUNNEL)
+
+KUBECTL_CMD ?= $(KUBECTL_SSH_CMD) "$(KUBECTL)" --logtostderr=true --insecure-skip-tls-verify=true  
+
+#
+# Reference Docs:
+#  - https://cloud.google.com/container-engine/docs/kubectl/
+#
+## Display info about the kubernetes setup
+kubernetes\:info:
+	@echo -e "Cluster Namespace: $(call yellow,$(CLUSTER_NAMESPACE))"
+	@echo -e "Cluster Domain: $(call yellow,$(CLUSTER_DOMAIN))"
+	@echo -e "SSH Tunnel: $(call yellow,$(KUBECTL_SSH_TUNNEL))"
+	@echo -e "SSH User: $(call yellow,$(KUBECTL_SSH_USER))"
+
+# (private) Create a new service
+kubernetes\:create-service:
+	$(call kubectl_create,service)
+
+# (private) Delete a new service
+kubernetes\:delete-service:
+	$(call kubectl_delete,service)
+
+# (private) Replace an existing service with downtime
+kubernetes\:replace-service:
+	@echo -e "INFO: Replacing $(KUBERNETES_APP) service on cluster $(call yellow,$(CLUSTER_NAMESPACE))..."
+	@$(SELF) kubernetes:delete-service kubernetes:create-service
+
+# (private) Create a new controller
+kubernetes\:create-controller:
+	$(call kubectl_create,controller)
+
+# (private) Delete a new controller
+kubernetes\:delete-controller:
+	$(call kubectl_delete,controller)
+
+# (private) Replace an existing controller with downtime
+kubernetes\:replace-controller:
+	@echo -e "INFO: Replacing $(KUBERNETES_APP) controller on cluster $(call yellow,$(CLUSTER_NAMESPACE))..."
+	@$(SELF) kubernetes:delete-controller kubernetes:create-controller
+
+# (private) Replace an app composed of a service and a controller with downtime
+kubernetes\:replace:
+	@$(SELF) kubernetes:replace-service kubernetes:replace-controller
+
+# (private) Update existing controller using rolling-update or create a new controller; do not notify datadog
+kubernetes\:deploy-controller:
+	$(eval CURRENT_CONTROLLER_NAME = $(shell $(KUBECTL_CMD) get rc --selector="app=$(KUBERNETES_APP)" -o jsonpath="{.items[0].metadata.name}" 2>/dev/null))
+	@if [ -z "$(CURRENT_CONTROLLER_NAME)" ]; then \
+  	$(SELF) kubernetes\:create-controller; \
+  else \
+		echo -e "INFO: Performing Rolling Update on $(KUBERNETES_APP) on cluster $(call yellow,$(CLUSTER_NAMESPACE))..."; \
+	  envsubst < "$(KUBERNETES_RESOURCE_PATH)/$(KUBERNETES_APP)-controller.yml" | envsubst | \
+    	$(KUBECTL_CMD) rolling-update $(CURRENT_CONTROLLER_NAME) $(KUBECTL_SCHEMA_CACHE_DIR) -f - ; \
+	fi
+
+# (private) Replace existing service causing downtime if serial of resource has changed or create a service if one does not already exist; do not notify datadog
+kubernetes\:deploy-service:
+	$(eval CURRENT_SERIAL = $(shell $(KUBECTL_CMD) get svc --selector="app=$(KUBERNETES_APP)" -o jsonpath="{.items[0].metadata.labels.serial}" 2>/dev/null))
+	$(eval NEXT_SERIAL = $(shell grep 'serial:' $(KUBERNETES_RESOURCE_PATH)/$(KUBERNETES_APP)-service.yml | cut -d'"' -f2))
+	@if [ "$(CURRENT_SERIAL)" == "$(NEXT_SERIAL)" ]; then \
+	  echo -e "INFO: Current serial $(CURRENT_SERIAL) is up to date for $(KUBERNETES_APP) service on cluster $(call yellow,$(CLUSTER_NAMESPACE)), skipping replacement"; \
+  else  \
+		echo -e "INFO: Serial changed from '$(CURRENT_SERIAL)' to '$(NEXT_SERIAL)'"; \
+	  $(SELF) kubernetes:replace; \
+  fi
+
+## Deploy controller and service; notify datadog
+kubernetes\:deploy:
+	$(NOTIFY_STARTING)
+	@$(SELF) kubernetes:deploy-controller kubernetes:deploy-service || $(NOTIFY_FAILURE)
+	$(NOTIFY_SUCCESS)
+
+

--- a/modules/datadog/Makefile
+++ b/modules/datadog/Makefile
@@ -1,0 +1,32 @@
+
+.PHONY : datadog\:notify-deploy-starting \
+        datadog\:notify-deploy-success \
+        datadog\:notify-deploy-failure
+
+CURL := curl --silent -X POST -H "Content-type: application/json" -d @- 'https://app.datadoghq.com/api/v1/events?api_key=$(DATADOG_API_KEY)' > /dev/null
+
+NOTIFY_SUCCESS ?= @$(SELF) datadog:notify-deploy-success
+NOTIFY_FAILURE ?= ($(SELF) datadog:notify-deploy-failure; exit 1)
+NOTIFY_STARTING ?= @$(SELF) datadog:notify-deploy-starting
+
+define datadog_notify
+	$(call assert,KUBERNETES_APP)
+	$(call assert,DATADOG_API_KEY)
+	$(call assert,CLUSTER_NAMESPACE)
+	$(call assert,IMAGE_TAG)
+	$(call assert,CIRCLE_BUILD_NUM)
+	$(call assert,CIRCLE_BRANCH)
+	@envsubst < $(MAKEFILE_DIR)/modules/datadog/$(1).json | $(CURL)
+endef
+
+## Notify datadog a deploy is starting
+datadog\:notify-deploy-starting:
+	$(call datadog_notify,$(subst datadog:notify-,,$@))
+
+## datadog datadog a deploy was successful
+datadog\:notify-deploy-success:
+	$(call datadog_notify,$(subst datadog:notify-,,$@))
+
+## datadog datadog a deploy failure
+datadog\:notify-deploy-failure:
+	$(call datadog_notify,$(subst datadog:notify-,,$@))

--- a/modules/datadog/deploy-failure.json
+++ b/modules/datadog/deploy-failure.json
@@ -1,0 +1,9 @@
+{
+  "title": "Failed to deploy $KUBERNETES_APP-$CIRCLE_BUILD_NUM to $CLUSTER_NAMESPACE",
+  "text": "Failed to deploy $KUBERNETES_APP build $CIRCLE_BUILD_NUM from branch $CIRCLE_BRANCH to $CLUSTER_NAMESPACE",
+  "priority": "normal",
+  "tags": ["namespace:$CLUSTER_NAMESPACE","app:$KUBERNETES_APP","image:$IMAGE_TAG","build_number:$CIRCLE_BUILD_NUM","branch:$CIRCLE_BRANCH"],
+  "alert_type": "error",
+  "source_type_name": "circleci",
+  "aggregation_key": "$CLUSTER_NAMESPACE-$KUBERNETES_APP-$CIRCLE_BUILD_NUM"
+}

--- a/modules/datadog/deploy-starting.json
+++ b/modules/datadog/deploy-starting.json
@@ -1,0 +1,10 @@
+{
+  "title": "Deploying $KUBERNETES_APP-$CIRCLE_BUILD_NUM to $CLUSTER_NAMESPACE",
+  "text": "Deploying $KUBERNETES_APP build $CIRCLE_BUILD_NUM from branch $CIRCLE_BRANCH to $CLUSTER_NAMESPACE",
+  "priority": "normal",
+  "tags": ["namespace:$CLUSTER_NAMESPACE","app:$KUBERNETES_APP","image:$IMAGE_TAG","build_number:$CIRCLE_BUILD_NUM","branch:$CIRCLE_BRANCH"],
+  "alert_type": "info",
+  "source_type_name": "circleci",
+  "aggregation_key": "$CLUSTER_NAMESPACE-$KUBERNETES_APP-$CIRCLE_BUILD_NUM"
+}
+

--- a/modules/datadog/deploy-success.json
+++ b/modules/datadog/deploy-success.json
@@ -1,0 +1,9 @@
+{
+  "title": "Deployed $KUBERNETES_APP-$CIRCLE_BUILD_NUM to $CLUSTER_NAMESPACE",
+  "text": "Deployed $KUBERNETES_APP build $CIRCLE_BUILD_NUM from branch $CIRCLE_BRANCH to $CLUSTER_NAMESPACE",
+  "priority": "normal",
+  "tags": ["namespace:$CLUSTER_NAMESPACE","app:$KUBERNETES_APP","image:$IMAGE_TAG","build_number:$CIRCLE_BUILD_NUM","branch:$CIRCLE_BRANCH"],
+  "alert_type": "success",
+  "source_type_name": "circleci",
+  "aggregation_key": "$CLUSTER_NAMESPACE-$KUBERNETES_APP-$CIRCLE_BUILD_NUM"
+}


### PR DESCRIPTION
## What
* Define targets necessary to deploy controllers & services on kubernetes over ssh via Circle

## Why
* Old kubernetes-harness grew overly complicated as the expectations of what it should do changed.  
* By reducing the functionality we can simplify the procedure for integration with `circle.yml` by simply calling `kubernetes:deploy`

![image](https://cloud.githubusercontent.com/assets/52489/14092803/4c0e336a-f4fe-11e5-9680-adcb600448e3.png)

![image](https://cloud.githubusercontent.com/assets/52489/14094776/57345fb6-f50e-11e5-84e0-4033a57a4c1b.png)





## Who
@darend 