### PR TITLE
Make sure correct docker build version arg selected by circle

### DIFF
--- a/modules/Makefile.circleci
+++ b/modules/Makefile.circleci
@@ -1,7 +1,12 @@
 DOCKER_DOWNLOAD_URL = https://s3-external-1.amazonaws.com/circle-downloads/docker-$(DOCKER_VERSION)-circleci
 DOCKER_CMD = /usr/bin/docker
 
+ifdef CIRCLE_TAG
+BUILD ?= $(CIRCLE_TAG)
+else
 BUILD ?= $(CIRCLE_BRANCH)-$(CIRCLE_BUILD_NUM)
+endif
+
 COMMIT ?= $(CIRCLE_SHA1)
 RELEASE ?= release-$(shell date -u +'%Y%m%d%H%M%SZ')
 DOCKER_BUILD_OPTS += --build-arg build=$(BUILD) --build-arg commit=$(COMMIT) 


### PR DESCRIPTION
**What**
- Since docker images are build in dependencies instead of deployment, make needs to sense if tag or branch build

**Why**
Otherwise tag builds will have the correct docker image tag, but not the right $build arg baked in