### PR TITLE
Kubernetes improvements

### DIFF
--- a/modules/Makefile.circleci
+++ b/modules/Makefile.circleci
@@ -43,7 +43,7 @@ circle\:release:
 circle\:deploy-kubernetes:
 	$(call assert,CIRCLE_BRANCH)
 	@if [ -z "$(CIRCLE_TOKEN)" ]; then \
-    echo "WARN: Deploying $(RELEASE) without obtaining lock; CIRCLE_TOKEN not defined"; \
+    echo "$(call red,WARN:) Deploying $(RELEASE) without obtaining lock; CIRCLE_TOKEN not defined"; \
     $(SELF) kubernetes:info kubernetes:deploy; \
   else \
 	  echo "INFO: Deploying $(RELEASE)"; \

--- a/modules/Makefile.circleci
+++ b/modules/Makefile.circleci
@@ -36,5 +36,12 @@ circle\:tag-latest:
 circle\:release:
 	@$(call assert_set,RELEASE)
 	@$(SELF) docker:login
-	@echo "INFO: Tagging $(RELEASE)"
+	@echo "INFO: Releasing $(RELEASE)"
 	@$(SELF) DOCKER_TAG=$(RELEASE) docker:tag docker:push
+
+## Deploy to kubernetes after obtaining an exclusive lock
+circle\:deploy-kubernetes:
+	$(call assert,CIRCLE_BRANCH)
+	@echo "INFO: Deploying $(RELEASE)"
+	@$(MAKEFILE_DIR)/bin/circle-do-exclusively.sh --branch $(CIRCLE_BRANCH) $(SELF) kubernetes:info kubernetes:deploy
+

--- a/modules/Makefile.circleci
+++ b/modules/Makefile.circleci
@@ -44,9 +44,9 @@ circle\:deploy-kubernetes:
 	$(call assert,CIRCLE_BRANCH)
 	@if [ -z "$(CIRCLE_TOKEN)" ]; then \
     echo "$(call red,WARN:) Deploying $(RELEASE) without obtaining lock; CIRCLE_TOKEN not defined"; \
-    $(SELF) kubernetes:info kubernetes:deploy; \
+    $(SELF) circle:tag kubernetes:info kubernetes:deploy; \
   else \
 	  echo "INFO: Deploying $(RELEASE)"; \
-	  $(MAKEFILE_DIR)/bin/circle-do-exclusively.sh --branch $(CIRCLE_BRANCH) $(SELF) kubernetes:info kubernetes:deploy; \
+	  $(MAKEFILE_DIR)/bin/circle-do-exclusively.sh --branch $(CIRCLE_BRANCH) $(SELF) circle:tag kubernetes:info kubernetes:deploy; \
   fi
 

--- a/modules/Makefile.circleci
+++ b/modules/Makefile.circleci
@@ -43,7 +43,7 @@ circle\:release:
 circle\:deploy-kubernetes:
 	$(call assert,CIRCLE_BRANCH)
 	@if [ -z "$(CIRCLE_TOKEN)" ]; then \
-    echo "$(call red,WARN:) Deploying $(RELEASE) without obtaining lock; CIRCLE_TOKEN not defined"; \
+    echo -e "$(call red,WARN:) Deploying $(RELEASE) without obtaining lock; CIRCLE_TOKEN not defined"; \
     $(SELF) circle:tag kubernetes:info kubernetes:deploy; \
   else \
 	  echo "INFO: Deploying $(RELEASE)"; \

--- a/modules/Makefile.circleci
+++ b/modules/Makefile.circleci
@@ -42,6 +42,11 @@ circle\:release:
 ## Deploy to kubernetes after obtaining an exclusive lock
 circle\:deploy-kubernetes:
 	$(call assert,CIRCLE_BRANCH)
-	@echo "INFO: Deploying $(RELEASE)"
-	@$(MAKEFILE_DIR)/bin/circle-do-exclusively.sh --branch $(CIRCLE_BRANCH) $(SELF) kubernetes:info kubernetes:deploy
+	@if [ -z "$(CIRCLE_TOKEN)" ]; then \
+    echo "WARN: Deploying $(RELEASE) without obtaining lock; CIRCLE_TOKEN not defined"; \
+    $(SELF) kubernetes:info kubernetes:deploy; \
+  else \
+	  echo "INFO: Deploying $(RELEASE)"; \
+	  $(MAKEFILE_DIR)/bin/circle-do-exclusively.sh --branch $(CIRCLE_BRANCH) $(SELF) kubernetes:info kubernetes:deploy; \
+  fi
 

--- a/modules/Makefile.kubernetes
+++ b/modules/Makefile.kubernetes
@@ -87,7 +87,7 @@ kubernetes\:replace:
 
 # (private) Update existing controller using rolling-update or create a new controller; do not notify datadog
 kubernetes\:deploy-controller:
-	$(eval CURRENT_CONTROLLER_NAME = $(shell $(KUBECTL_CMD) get rc --selector="app=$(KUBERNETES_APP)" -o jsonpath="{.items[0].metadata.name}" 2>/dev/null))
+	$(eval CURRENT_CONTROLLER_NAME = $(shell $(KUBECTL_CMD) get rc --selector="app=$(KUBERNETES_APP)" -o jsonpath="{.items[0].metadata.name}" 2>/dev/null || true))
 	@if [ -z "$(CURRENT_CONTROLLER_NAME)" ]; then \
   	$(SELF) kubernetes\:create-controller; \
   else \
@@ -98,7 +98,7 @@ kubernetes\:deploy-controller:
 
 # (private) Replace existing service causing downtime if serial of resource has changed or create a service if one does not already exist; do not notify datadog
 kubernetes\:deploy-service:
-	$(eval CURRENT_SERIAL = $(shell $(KUBECTL_CMD) get svc --selector="app=$(KUBERNETES_APP)" -o jsonpath="{.items[0].metadata.labels.serial}" 2>/dev/null))
+	$(eval CURRENT_SERIAL = $(shell $(KUBECTL_CMD) get svc --selector="app=$(KUBERNETES_APP)" -o jsonpath="{.items[0].metadata.labels.serial}" 2>/dev/null || true))
 	$(eval NEXT_SERIAL = $(shell grep 'serial:' $(KUBERNETES_RESOURCE_PATH)/$(KUBERNETES_APP)-service.yml | cut -d'"' -f2))
 	@if [ "$(CURRENT_SERIAL)" == "$(NEXT_SERIAL)" ]; then \
 	  echo -e "INFO: Current serial $(CURRENT_SERIAL) is up to date for $(KUBERNETES_APP) service on cluster $(call yellow,$(CLUSTER_NAMESPACE)), skipping replacement"; \

--- a/modules/Makefile.kubernetes
+++ b/modules/Makefile.kubernetes
@@ -87,13 +87,13 @@ kubernetes\:replace:
 
 # (private) Update existing controller using rolling-update or create a new controller; do not notify datadog
 kubernetes\:deploy-controller:
-	$(eval CURRENT_CONTROLLER_NAME = $(shell $(KUBECTL_CMD) get rc --selector="app=$(KUBERNETES_APP)" -o jsonpath="{.items[0].metadata.name}" 2>/dev/null || true))
-	@if [ -z "$(CURRENT_CONTROLLER_NAME)" ]; then \
+	@CURRENT_CONTROLLER_NAME=$$($(KUBECTL_CMD) get rc --selector="app=$(KUBERNETES_APP)" -o jsonpath="{.items[0].metadata.name}" 2>/dev/null); \
+  if [ -z "$$CURRENT_CONTROLLER_NAME" ] || [ $$? -ne 0 ]; then \
   	$(SELF) kubernetes\:create-controller; \
   else \
-		echo -e "INFO: Performing Rolling Update on $(KUBERNETES_APP) on cluster $(call yellow,$(CLUSTER_NAMESPACE))/$(CURRENT_CONTROLLER_NAME)..."; \
+		echo -e "INFO: Performing Rolling Update on $(KUBERNETES_APP) on cluster $(call yellow,$(CLUSTER_NAMESPACE))..."; \
 	  envsubst < "$(KUBERNETES_RESOURCE_PATH)/$(KUBERNETES_APP)-controller.yml" | envsubst | \
-    	$(KUBECTL_CMD) rolling-update $(CURRENT_CONTROLLER_NAME) $(KUBECTL_SCHEMA_CACHE_DIR) -f - ; \
+    	$(KUBECTL_CMD) rolling-update $$CURRENT_CONTROLLER_NAME $(KUBECTL_SCHEMA_CACHE_DIR) -f - ; \
 	fi
 
 # (private) Replace existing service causing downtime if serial of resource has changed or create a service if one does not already exist; do not notify datadog

--- a/modules/Makefile.kubernetes
+++ b/modules/Makefile.kubernetes
@@ -91,7 +91,7 @@ kubernetes\:deploy-controller:
 	@if [ -z "$(CURRENT_CONTROLLER_NAME)" ]; then \
   	$(SELF) kubernetes\:create-controller; \
   else \
-		echo -e "INFO: Performing Rolling Update on $(KUBERNETES_APP) on cluster $(call yellow,$(CLUSTER_NAMESPACE))..."; \
+		echo -e "INFO: Performing Rolling Update on $(KUBERNETES_APP) on cluster $(call yellow,$(CLUSTER_NAMESPACE))/$(CURRENT_CONTROLLER_NAME)..."; \
 	  envsubst < "$(KUBERNETES_RESOURCE_PATH)/$(KUBERNETES_APP)-controller.yml" | envsubst | \
     	$(KUBECTL_CMD) rolling-update $(CURRENT_CONTROLLER_NAME) $(KUBECTL_SCHEMA_CACHE_DIR) -f - ; \
 	fi

--- a/modules/Makefile.kubernetes
+++ b/modules/Makefile.kubernetes
@@ -110,7 +110,8 @@ kubernetes\:deploy-service:
 ## Deploy controller and service; notify datadog
 kubernetes\:deploy:
 	$(NOTIFY_STARTING)
-	@$(SELF) kubernetes:deploy-controller kubernetes:deploy-service || $(NOTIFY_FAILURE)
+	@[ ! -f "$(KUBERNETES_RESOURCE_PATH)/$(KUBERNETES_APP)-controller.yml" ] || $(SELF) kubernetes:deploy-controller || $(NOTIFY_FAILURE)
+	@[ ! -f "$(KUBERNETES_RESOURCE_PATH)/$(KUBERNETES_APP)-service.yml" ] || $(SELF) kubernetes:deploy-service || $(NOTIFY_FAILURE)
 	$(NOTIFY_SUCCESS)
 
 


### PR DESCRIPTION
## what
* `|| true` if unable to query `kubectl` for existing controller or service
* Add a new `circle:deploy-kubernetes` target that attempts to do exclusive deployment
* Make `kubernetes:deploy` smarter about what it attempts to deploy since not all applications will expose a service

## why
* using scripts like `circle-do-exclusively.sh` is a great way to move complex logic out of the `Makefile`. The problem with scripts is that there's no consistent interface to working with them. By adding the target `circle:deploy-kubernetes` the caller doesn't need to be concerned about the underlying script changing arguments around. 
* The `synthetic` service does not expose an HTTP service at this point. Attempting to do a deploy with out a `...-service.yml` file will cause a failure. It makes more sense that the `kubernetes:deploy` figure out what it needs to deploy than assume it always needs to deploy both.
* When deploying a service to a cluster for the first time, it would fail because the `kubectl` command used to query the API for the current version would exit non-zero. If the output is empty, we assume at this time it means it doesn't exist.

## who
@darend 
cc: @aargonda 