### PR TITLE
Forcefully tag builds with `-f`

### DIFF
--- a/modules/Makefile.docker
+++ b/modules/Makefile.docker
@@ -94,7 +94,7 @@ docker\:test:
 ## Tag the last built image with `DOCKER_TAG`
 docker\:tag: env
 	@echo INFO: Tagging $(DOCKER_REPOSITORY):$(DOCKER_BUILD_TAG) as $(DOCKER_URI)
-	@$(DOCKER_CMD) tag "$(DOCKER_REPOSITORY):$(DOCKER_BUILD_TAG)" "$(DOCKER_URI)"
+	@$(DOCKER_CMD) tag -f "$(DOCKER_REPOSITORY):$(DOCKER_BUILD_TAG)" "$(DOCKER_URI)"
 
 ## Remove existing docker images
 docker\:clean: env


### PR DESCRIPTION
## what
* add `-f` to the `docker tag`

## why
* might tag same build multiple times (e.g. when deploying to multiple clusters) 

## caveats
* `-f` is deprecated and implied on docker > 1.10.x

## who
@darend 