### PR TITLE
Add jq via apt-get to fix CircleCI

### DIFF
--- a/bin/circleci.sh
+++ b/bin/circleci.sh
@@ -13,3 +13,6 @@ fi
 git clone -b $BUILD_HARNESS_BRANCH $GITHUB_REPO
 make -C $BUILD_HARNESS_PROJECT deps circle:deps
 
+# because as of 2016-04-25, the Ubuntu 14 (experimental) version
+# of CircleCI doesn't have it and it's needed for circle-do-exclusively.sh
+sudo apt-get install -y jq


### PR DESCRIPTION
## Why
* Because I changed Supernova's CircleCI container from Ubuntu 12 to 14 ( to get Postgres 9.5 ) and it's missing `jq` which we use in our `circle-do-exclusively.sh`
  * failing build: https://circleci.com/gh/sagansystems/supernova/6377?utm_campaign=build-failed&utm_medium=email&utm_source=notification
  * genesis of Ubuntu 14 change https://github.com/sagansystems/supernova/pull/1500#issuecomment-214469070

## Who
@darend @osterman 