### PR TITLE
Add jq via download to fix CircleCI (attempt 2)

### DIFF
--- a/bin/circleci.sh
+++ b/bin/circleci.sh
@@ -15,4 +15,4 @@ make -C $BUILD_HARNESS_PROJECT deps circle:deps
 
 # because as of 2016-04-25, the Ubuntu 14 (experimental) version
 # of CircleCI doesn't have it and it's needed for circle-do-exclusively.sh
-sudo apt-get install -y jq
+curl -LO https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 && sudo cp jq-linux64 /usr/local/bin/jq && source ~/.bash_profile


### PR DESCRIPTION
Attempt 2 of https://github.com/sagansystems/build-harness/pull/18

## Why
Because apt-get install (even after apt-get update) was installing `jq 1.3` (we need `1.4` or `1.5`)