### PR TITLE
Load bash_profile, then gracefully degrade to bashrc

### DIFF
--- a/bin/circleci.sh
+++ b/bin/circleci.sh
@@ -15,4 +15,4 @@ make -C $BUILD_HARNESS_PROJECT deps circle:deps
 
 # because as of 2016-04-25, the Ubuntu 14 (experimental) version
 # of CircleCI doesn't have it and it's needed for circle-do-exclusively.sh
-curl -LO https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 && sudo cp jq-linux64 /usr/local/bin/jq && source ~/.bash_profile
+curl -LO https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 && sudo cp jq-linux64 /usr/local/bin/jq && (source ~/.bash_profile 2>/dev/null || source ~/.bashrc)


### PR DESCRIPTION
## Why

![image](https://cloud.githubusercontent.com/assets/16573/14797424/a032c8d0-0ae7-11e6-8af4-47f538e2ce09.png)

https://circleci.com/gh/sagansystems/agent-desktop/11244

## Context

see https://github.com/sagansystems/build-harness/pull/19 and https://github.com/sagansystems/build-harness/pull/18