### PR TITLE
Check if `jq` already installed otherwise install it

### DIFF
--- a/bin/circleci.sh
+++ b/bin/circleci.sh
@@ -3,7 +3,6 @@ export DOCKER_VERSION=${1:-1.9.1}
 export BUILD_HARNESS_PROJECT=${2:-build-harness}
 export BUILD_HARNESS_BRANCH=${3:-master}
 export GITHUB_REPO="git@github.com:sagansystems/${BUILD_HARNESS_PROJECT}.git"
-export PATH="$PATH:/usr/local/bin"
 
 cd ~
 if [ "$BUILD_HARNESS_PROJECT" ] && [ -d "$BUILD_HARNESS_PROJECT" ]; then

--- a/bin/circleci.sh
+++ b/bin/circleci.sh
@@ -3,6 +3,7 @@ export DOCKER_VERSION=${1:-1.9.1}
 export BUILD_HARNESS_PROJECT=${2:-build-harness}
 export BUILD_HARNESS_BRANCH=${3:-master}
 export GITHUB_REPO="git@github.com:sagansystems/${BUILD_HARNESS_PROJECT}.git"
+export PATH="$PATH:/usr/local/bin"
 
 cd ~
 if [ "$BUILD_HARNESS_PROJECT" ] && [ -d "$BUILD_HARNESS_PROJECT" ]; then
@@ -15,5 +16,10 @@ make -C $BUILD_HARNESS_PROJECT deps circle:deps
 
 # because as of 2016-04-25, the Ubuntu 14 (experimental) version
 # of CircleCI doesn't have it and it's needed for circle-do-exclusively.sh
-curl -LO https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 && sudo cp jq-linux64 /usr/local/bin/jq && (source ~/.bash_profile 2>/dev/null || source ~/.bashrc)
-sudo chown ubuntu:ubuntu /usr/local/bin/jq && chmod +x /usr/local/bin/jq
+which jq >/dev/null
+if [ $? -ne 0 ]; then                                                                                                                                                                                                                                                                                                                                                     
+  sudo curl -s -q -L https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 -o /usr/local/bin/jq 
+  sudo chown ubuntu:ubuntu /usr/local/bin/jq
+  sudo chmod 755 /usr/local/bin/jq
+fi
+


### PR DESCRIPTION
## what
* use sudo for `chmod` or else that will also fail
* check if `jq` installed, otherwise fetch it
* tell curl to download directly into `/usr/local/bin/jq`

## why
* bug fix: `sudo chown ubuntu:ubuntu /usr/local/bin/jq && chmod +x /usr/local/bin/jq` would run the first part as sudo, but the second part as the current user since `&&` is a shell operator and not passed to `sudo`

## testing
* I just cut and paste the commands into a circleci shell to confirm they work as expected

## who
@jotto 
cc: @darend 