### PR TITLE
Support kubernetes deployment type

### DIFF
--- a/modules/Makefile.circleci
+++ b/modules/Makefile.circleci
@@ -8,8 +8,13 @@ BUILD ?= $(CIRCLE_BRANCH)-$(CIRCLE_BUILD_NUM)
 endif
 
 COMMIT ?= $(CIRCLE_SHA1)
+COMMIT_LOG ?= $(shell git log --format=oneline --pretty=format:'%s' -n 1 $(CIRCLE_SHA1))
 RELEASE ?= release-$(shell date -u +'%Y%m%d%H%M%SZ')
 DOCKER_BUILD_OPTS += --build-arg build=$(BUILD) --build-arg commit=$(COMMIT) 
+
+export COMMIT
+export COMMIT_LOG
+export RELEASE
 
 .PHONY : circle\:tag circle\:release circle\:deps
 
@@ -50,5 +55,3 @@ circle\:deploy-kubernetes:
 	  echo "INFO: Deploying $(RELEASE)"; \
 	  $(MAKEFILE_DIR)/bin/circle-do-exclusively.sh --branch $(CIRCLE_BRANCH) $(SELF) kubernetes:deploy; \
   fi
-	$(SELF) kubernetes:list-rc kubernetes:list-svc
-

--- a/modules/Makefile.kubernetes
+++ b/modules/Makefile.kubernetes
@@ -20,11 +20,13 @@ export SERIAL
 
 define kubectl_create
 	@echo -e "INFO: Creating $(KUBERNETES_APP) $(1) on cluster $(call yellow,$(CLUSTER_NAMESPACE))..."
+	@[ -z "$(DEBUG)" ] && (envsubst < "$(KUBERNETES_RESOURCE_PATH)/$(KUBERNETES_APP)-$(1).yml" | envsubst)
 	@envsubst < "$(KUBERNETES_RESOURCE_PATH)/$(KUBERNETES_APP)-$(1).yml" | envsubst | $(KUBECTL_CMD) create $(KUBECTL_SCHEMA_CACHE_DIR) -f -
 endef
 
 define kubectl_delete
 	@echo -e "INFO: Deleteting $(KUBERNETES_APP) $(1) on cluster $(call yellow,$(CLUSTER_NAMESPACE))..."
+	@[ -z "$(DEBUG)" ] || (envsubst < "$(KUBERNETES_RESOURCE_PATH)/$(KUBERNETES_APP)-$(1).yml" | envsubst)
 	@envsubst < "$(KUBERNETES_RESOURCE_PATH)/$(KUBERNETES_APP)-$(1).yml" | envsubst | $(KUBECTL_CMD) delete --ignore-not-found=true -f -
 endef
 
@@ -59,7 +61,7 @@ kubernetes\:info:
 kubernetes\:create-service:
 	$(call kubectl_create,service)
 
-# (private) Delete a new service
+# (private) Delete a service
 kubernetes\:delete-service:
 	$(call kubectl_delete,service)
 
@@ -72,7 +74,7 @@ kubernetes\:replace-service:
 kubernetes\:create-controller:
 	$(call kubectl_create,controller)
 
-# (private) Delete a new controller
+# (private) Delete a controller
 kubernetes\:delete-controller:
 	$(call kubectl_delete,controller)
 
@@ -85,18 +87,47 @@ kubernetes\:replace-controller:
 kubernetes\:replace:
 	@$(SELF) kubernetes:replace-service kubernetes:replace-controller
 
+# (private) Create a new deployment
+kubernetes\:create-deployment:
+	$(call kubectl_create,deployment)
+
+# (private) Delete a deploymentt
+kubernetes\:delete-deployment:
+	$(call kubectl_delete,deployment)
+
+## Show deployment history
+kubernetes\:list-deployments:
+	@$(KUBECTL_CMD) rollout history deployment $(KUBERNETES_APP)
+
+# (private) Update existing controller using rolling-update or create a new controller; do not notify datadog
+kubernetes\:apply-deployment:
+	@echo -e "INFO: Applying updates to $(KUBERNETES_APP) deployment on cluster $(call yellow,$(CLUSTER_NAMESPACE))..."
+	@[ -z "$(DEBUG)" ] || (envsubst < "$(KUBERNETES_RESOURCE_PATH)/$(KUBERNETES_APP)-deployment.yml" | envsubst)
+	@envsubst < "$(KUBERNETES_RESOURCE_PATH)/$(KUBERNETES_APP)-deployment.yml" | envsubst | \
+      $(KUBECTL_CMD) apply --record=false $(KUBECTL_SCHEMA_CACHE_DIR) -f -
+	@$(SELF) kubernetes:list-deployments kubernetes:list-rs
+
+## Rollback to previous deployment
+kubernetes\:undo-deployment:
+	@echo -e "INFO: Rolling back to previous deployment of $(KUBERNETES_APP) on cluster $(call yellow,$(CLUSTER_NAMESPACE))..."
+	@$(KUBECTL_CMD) rollout undo deployment $(KUBERNETES_APP)
+	@$(SELF) kubernetes:list-deployments kubernetes:list-rs
+
+
 # (private) Update existing controller using rolling-update or create a new controller; do not notify datadog
 kubernetes\:deploy-controller:
 	@CURRENT_CONTROLLER_NAME=$$($(KUBECTL_CMD) get rc --selector="app=$(KUBERNETES_APP)" -o jsonpath="{.items[0].metadata.name}" 2>/dev/null); \
 	RESULT_CODE=$$?; \
   if [ -z "$$CURRENT_CONTROLLER_NAME" ] || [ $$RESULT_CODE -ne 0 ]; then \
 		echo -e "INFO: No existing controller found for $(KUBERNETES_APP) on cluster $(call yellow,$(CLUSTER_NAMESPACE)), creating one ..."; \
-		$(SELF) kubernetes\:create-controller; \
+		$(SELF) kubernetes:create-controller; \
   else \
 		echo -e "INFO: Performing Rolling Update on $(KUBERNETES_APP) on cluster $(call yellow,$(CLUSTER_NAMESPACE))..."; \
+	  [ -z "$(DEBUG)" ] || (envsubst < "$(KUBERNETES_RESOURCE_PATH)/$(KUBERNETES_APP)-controller.yml" | envsubst); \
 	  envsubst < "$(KUBERNETES_RESOURCE_PATH)/$(KUBERNETES_APP)-controller.yml" | envsubst | \
 		$(KUBECTL_CMD) rolling-update $$CURRENT_CONTROLLER_NAME $(KUBECTL_SCHEMA_CACHE_DIR) -f - ; \
 	fi
+	@$(SELF) kubernetes:list-rc
 
 # (private) Replace existing service causing downtime if serial of resource has changed or create a service if one does not already exist; do not notify datadog
 kubernetes\:deploy-service:
@@ -106,12 +137,14 @@ kubernetes\:deploy-service:
 	  echo -e "INFO: Current serial $(CURRENT_SERIAL) is up to date for $(KUBERNETES_APP) service on cluster $(call yellow,$(CLUSTER_NAMESPACE)), skipping replacement"; \
   else  \
 		echo -e "INFO: Serial changed from '$(CURRENT_SERIAL)' to '$(NEXT_SERIAL)'"; \
-	  $(SELF) kubernetes:replace; \
-  fi
+	  $(SELF) kubernetes:replace-service; \
+  fi; \
+  $(SELF) kubernetes:list-svc
 
 ## Deploy controller and service; notify datadog
 kubernetes\:deploy:
 	$(NOTIFY_STARTING)
+	@[ ! -f "$(KUBERNETES_RESOURCE_PATH)/$(KUBERNETES_APP)-deployment.yml" ] || $(SELF) kubernetes:apply-deployment || $(NOTIFY_FAILURE)
 	@[ ! -f "$(KUBERNETES_RESOURCE_PATH)/$(KUBERNETES_APP)-controller.yml" ] || $(SELF) kubernetes:deploy-controller || $(NOTIFY_FAILURE)
 	@[ ! -f "$(KUBERNETES_RESOURCE_PATH)/$(KUBERNETES_APP)-service.yml" ] || $(SELF) kubernetes:deploy-service || $(NOTIFY_FAILURE)
 	$(NOTIFY_SUCCESS)
@@ -119,6 +152,10 @@ kubernetes\:deploy:
 ## List deployed replication controllers
 kubernetes\:list-rc:
 	@$(KUBECTL_CMD) get rc
+
+## List deployed replica sets
+kubernetes\:list-rs:
+	@$(KUBECTL_CMD) get rs
 
 ## List deployed services
 kubernetes\:list-svc:

--- a/modules/Makefile.kubernetes
+++ b/modules/Makefile.kubernetes
@@ -98,6 +98,7 @@ kubernetes\:delete-deployment:
 
 ## Show deployment history
 kubernetes\:list-deployments:
+	@echo -e "INFO: Listing deployments of $(KUBERNETES_APP) on cluster $(call yellow,$(CLUSTER_NAMESPACE))..."
 	@$(KUBECTL_CMD) rollout history deployment $(KUBERNETES_APP)
 
 # (private) Update existing controller using rolling-update or create a new controller; do not notify datadog
@@ -142,6 +143,7 @@ kubernetes\:deploy-service:
 
 ## Deploy controller and service; notify datadog
 kubernetes\:deploy:
+	@echo -e "INFO: Deploying $(KUBERNETES_APP) resources on cluster $(call yellow,$(CLUSTER_NAMESPACE))..."
 	$(NOTIFY_STARTING)
 	@[ ! -f "$(KUBERNETES_RESOURCE_PATH)/$(KUBERNETES_APP)-deployment.yml" ] || $(SELF) kubernetes:apply-deployment || $(NOTIFY_FAILURE)
 	@[ ! -f "$(KUBERNETES_RESOURCE_PATH)/$(KUBERNETES_APP)-controller.yml" ] || $(SELF) kubernetes:deploy-controller || $(NOTIFY_FAILURE)
@@ -150,12 +152,15 @@ kubernetes\:deploy:
 
 ## List deployed replication controllers
 kubernetes\:list-rc:
+	@echo -e "INFO: Listing replication controllers on cluster $(call yellow,$(CLUSTER_NAMESPACE))..."
 	@$(KUBECTL_CMD) get rc
 
 ## List deployed replica sets
 kubernetes\:list-rs:
+	@echo -e "INFO: Listing replica sets on cluster $(call yellow,$(CLUSTER_NAMESPACE))..."
 	@$(KUBECTL_CMD) get rs
 
 ## List deployed services
 kubernetes\:list-svc:
+	@echo -e "INFO: Listing services on cluster $(call yellow,$(CLUSTER_NAMESPACE))..."
 	@$(KUBECTL_CMD) get svc

--- a/modules/Makefile.kubernetes
+++ b/modules/Makefile.kubernetes
@@ -22,7 +22,7 @@ export SERIAL
 DEBUG ?= /dev/null
 
 define envsubst 
-	envsubst < "$(1)" | envsubst | tee $(DEBUG))
+	envsubst < "$(1)" | envsubst | tee $(DEBUG)
 endef
 
 define kubectl_create

--- a/modules/Makefile.kubernetes
+++ b/modules/Makefile.kubernetes
@@ -18,16 +18,20 @@ KUBECTL_SSH_TUNNEL ?= $(KUBECTL_SSH_USER)@$(CLUSTER_BASTION)
 SERIAL ?= $(shell echo -n $$(date +%s) | tail -c 5)
 export SERIAL
 
+DEBUG ?= /dev/null
+
+define envsubst 
+	envsubst < "$(1)" | envsubst | tee $(DEBUG))
+endef
+
 define kubectl_create
 	@echo -e "INFO: Creating $(KUBERNETES_APP) $(1) on cluster $(call yellow,$(CLUSTER_NAMESPACE))..."
-	@[ -z "$(DEBUG)" ] && (envsubst < "$(KUBERNETES_RESOURCE_PATH)/$(KUBERNETES_APP)-$(1).yml" | envsubst)
-	@envsubst < "$(KUBERNETES_RESOURCE_PATH)/$(KUBERNETES_APP)-$(1).yml" | envsubst | $(KUBECTL_CMD) create $(KUBECTL_SCHEMA_CACHE_DIR) -f -
+	@$(call envsubst,$(KUBERNETES_RESOURCE_PATH)/$(KUBERNETES_APP)-$(1).yml) | $(KUBECTL_CMD) create $(KUBECTL_SCHEMA_CACHE_DIR) -f -
 endef
 
 define kubectl_delete
 	@echo -e "INFO: Deleteting $(KUBERNETES_APP) $(1) on cluster $(call yellow,$(CLUSTER_NAMESPACE))..."
-	@[ -z "$(DEBUG)" ] || (envsubst < "$(KUBERNETES_RESOURCE_PATH)/$(KUBERNETES_APP)-$(1).yml" | envsubst)
-	@envsubst < "$(KUBERNETES_RESOURCE_PATH)/$(KUBERNETES_APP)-$(1).yml" | envsubst | $(KUBECTL_CMD) delete --ignore-not-found=true -f -
+	@$(call envsubst,$(KUBERNETES_RESOURCE_PATH)/$(KUBERNETES_APP)-$(1).yml) $(KUBECTL_CMD) delete --ignore-not-found=true -f -
 endef
 
 ifeq ($(CIRCLECI),true)
@@ -87,10 +91,6 @@ kubernetes\:replace-controller:
 kubernetes\:replace:
 	@$(SELF) kubernetes:replace-service kubernetes:replace-controller
 
-# (private) Create a new deployment
-kubernetes\:create-deployment:
-	$(call kubectl_create,deployment)
-
 # (private) Delete a deploymentt
 kubernetes\:delete-deployment:
 	$(call kubectl_delete,deployment)
@@ -102,8 +102,7 @@ kubernetes\:list-deployments:
 # (private) Update existing controller using rolling-update or create a new controller; do not notify datadog
 kubernetes\:apply-deployment:
 	@echo -e "INFO: Applying updates to $(KUBERNETES_APP) deployment on cluster $(call yellow,$(CLUSTER_NAMESPACE))..."
-	@[ -z "$(DEBUG)" ] || (envsubst < "$(KUBERNETES_RESOURCE_PATH)/$(KUBERNETES_APP)-deployment.yml" | envsubst)
-	@envsubst < "$(KUBERNETES_RESOURCE_PATH)/$(KUBERNETES_APP)-deployment.yml" | envsubst | \
+	@$(call envsubst,$(KUBERNETES_RESOURCE_PATH)/$(KUBERNETES_APP)-deployment.yml) \
       $(KUBECTL_CMD) apply --record=false $(KUBECTL_SCHEMA_CACHE_DIR) -f -
 	@$(SELF) kubernetes:list-deployments kubernetes:list-rs
 
@@ -123,8 +122,7 @@ kubernetes\:deploy-controller:
 		$(SELF) kubernetes:create-controller; \
   else \
 		echo -e "INFO: Performing Rolling Update on $(KUBERNETES_APP) on cluster $(call yellow,$(CLUSTER_NAMESPACE))..."; \
-	  [ -z "$(DEBUG)" ] || (envsubst < "$(KUBERNETES_RESOURCE_PATH)/$(KUBERNETES_APP)-controller.yml" | envsubst); \
-	  envsubst < "$(KUBERNETES_RESOURCE_PATH)/$(KUBERNETES_APP)-controller.yml" | envsubst | \
+	  $(call envsubst,$(KUBERNETES_RESOURCE_PATH)/$(KUBERNETES_APP)-controller.yml) \
 		$(KUBECTL_CMD) rolling-update $$CURRENT_CONTROLLER_NAME $(KUBECTL_SCHEMA_CACHE_DIR) -f - ; \
 	fi
 	@$(SELF) kubernetes:list-rc

--- a/modules/Makefile.kubernetes
+++ b/modules/Makefile.kubernetes
@@ -32,7 +32,7 @@ endef
 
 define kubectl_delete
 	@echo -e "INFO: Deleteting $(KUBERNETES_APP) $(1) on cluster $(call yellow,$(CLUSTER_NAMESPACE))..."
-	@$(call envsubst,$(KUBERNETES_RESOURCE_PATH)/$(KUBERNETES_APP)-$(1).yml) $(KUBECTL_CMD) delete --ignore-not-found=true -f -
+	@$(call envsubst,$(KUBERNETES_RESOURCE_PATH)/$(KUBERNETES_APP)-$(1).yml) | $(KUBECTL_CMD) delete --ignore-not-found=true -f -
 endef
 
 ifeq ($(CIRCLECI),true)
@@ -103,7 +103,7 @@ kubernetes\:list-deployments:
 # (private) Update existing controller using rolling-update or create a new controller; do not notify datadog
 kubernetes\:apply-deployment:
 	@echo -e "INFO: Applying updates to $(KUBERNETES_APP) deployment on cluster $(call yellow,$(CLUSTER_NAMESPACE))..."
-	@$(call envsubst,$(KUBERNETES_RESOURCE_PATH)/$(KUBERNETES_APP)-deployment.yml) \
+	@$(call envsubst,$(KUBERNETES_RESOURCE_PATH)/$(KUBERNETES_APP)-deployment.yml) | \
       $(KUBECTL_CMD) apply --record=false $(KUBECTL_SCHEMA_CACHE_DIR) -f -
 	@$(SELF) kubernetes:list-deployments kubernetes:list-rs
 
@@ -123,7 +123,7 @@ kubernetes\:deploy-controller:
 		$(SELF) kubernetes:create-controller; \
   else \
 		echo -e "INFO: Performing Rolling Update on $(KUBERNETES_APP) on cluster $(call yellow,$(CLUSTER_NAMESPACE))..."; \
-	  $(call envsubst,$(KUBERNETES_RESOURCE_PATH)/$(KUBERNETES_APP)-controller.yml) \
+	  $(call envsubst,$(KUBERNETES_RESOURCE_PATH)/$(KUBERNETES_APP)-controller.yml) | \
 		$(KUBECTL_CMD) rolling-update $$CURRENT_CONTROLLER_NAME $(KUBECTL_SCHEMA_CACHE_DIR) -f - ; \
 	fi
 	@$(SELF) kubernetes:list-rc

--- a/modules/Makefile.kubernetes
+++ b/modules/Makefile.kubernetes
@@ -96,24 +96,16 @@ kubernetes\:replace:
 kubernetes\:delete-deployment:
 	$(call kubectl_delete,deployment)
 
-## Show deployment history
-kubernetes\:list-deployments:
-	@echo -e "INFO: Listing deployments of $(KUBERNETES_APP) on cluster $(call yellow,$(CLUSTER_NAMESPACE))..."
-	@$(KUBECTL_CMD) rollout history deployment $(KUBERNETES_APP)
-
 # (private) Update existing controller using rolling-update or create a new controller; do not notify datadog
 kubernetes\:apply-deployment:
 	@echo -e "INFO: Applying updates to $(KUBERNETES_APP) deployment on cluster $(call yellow,$(CLUSTER_NAMESPACE))..."
 	@$(call envsubst,$(KUBERNETES_RESOURCE_PATH)/$(KUBERNETES_APP)-deployment.yml) | \
       $(KUBECTL_CMD) apply --record=false $(KUBECTL_SCHEMA_CACHE_DIR) -f -
-	@$(SELF) kubernetes:list-deployments kubernetes:list-rs
 
 ## Rollback to previous deployment
 kubernetes\:undo-deployment:
 	@echo -e "INFO: Rolling back to previous deployment of $(KUBERNETES_APP) on cluster $(call yellow,$(CLUSTER_NAMESPACE))..."
 	@$(KUBECTL_CMD) rollout undo deployment $(KUBERNETES_APP)
-	@$(SELF) kubernetes:list-deployments kubernetes:list-rs
-
 
 # (private) Update existing controller using rolling-update or create a new controller; do not notify datadog
 kubernetes\:deploy-controller:
@@ -164,3 +156,10 @@ kubernetes\:list-rs:
 kubernetes\:list-svc:
 	@echo -e "INFO: Listing services on cluster $(call yellow,$(CLUSTER_NAMESPACE))..."
 	@$(KUBECTL_CMD) get svc
+
+## Show deployment history
+kubernetes\:list-deployments:
+	@echo -e "INFO: Listing deployments of $(KUBERNETES_APP) on cluster $(call yellow,$(CLUSTER_NAMESPACE))..."
+	@$(KUBECTL_CMD) rollout history deployment $(KUBERNETES_APP)
+
+

--- a/modules/Makefile.kubernetes
+++ b/modules/Makefile.kubernetes
@@ -18,6 +18,7 @@ KUBECTL_SSH_TUNNEL ?= $(KUBECTL_SSH_USER)@$(CLUSTER_BASTION)
 SERIAL ?= $(shell echo -n $$(date +%s) | tail -c 5)
 export SERIAL
 
+# Specify DEBUG=/dev/stderr to get useful output to stderr 
 DEBUG ?= /dev/null
 
 define envsubst 


### PR DESCRIPTION
## what
* introduce support for `Deployment` type
* list deployments on circleci deploy

## why
* deployments eliminate the need for us to use the `SERIAL` variable to manage generations of a `ReplicationController`. Behind the scenes kubernetes now does this for us.
* deployments make it easier to rollback to any previous generation
* deployments won't clobber each other; if a deployment is currently underway and another deployment is triggered, the latest one will win and current deployment underway aborted
* deployments history makes it easy to review what changes to a cluster have been made

## who
@darend 

## related issues
https://github.com/kubernetes/kubernetes/issues/25554


DEV-4784