### PR TITLE
Annotate deployments

### DIFF
--- a/modules/Makefile.circleci
+++ b/modules/Makefile.circleci
@@ -50,7 +50,7 @@ circle\:deploy-kubernetes:
 	$(SELF) circle:tag kubernetes:info
 	@if [ -z "$(CIRCLE_TOKEN)" ]; then \
 	echo -e "$(call red,WARN:) Deploying $(RELEASE) without obtaining lock; CIRCLE_TOKEN not defined"; \
-	$(SELF) kubernetes:deploy; \
+	$(SELF) kubernetes:deploy KUBERNETES_ANNOTATION="$(RELEASE): $(BUILD) - $(COMMIT_LOG) ($(COMMIT))"; \
   else \
 	  echo "INFO: Deploying $(RELEASE)"; \
 	  $(MAKEFILE_DIR)/bin/circle-do-exclusively.sh --branch $(CIRCLE_BRANCH) $(SELF) kubernetes:deploy; \

--- a/modules/Makefile.kubernetes
+++ b/modules/Makefile.kubernetes
@@ -102,7 +102,7 @@ kubernetes\:apply-deployment:
 	@echo -e "INFO: Applying updates to $(KUBERNETES_APP) deployment on cluster $(call yellow,$(CLUSTER_NAMESPACE))..."
 	@$(call envsubst,$(KUBERNETES_RESOURCE_PATH)/$(KUBERNETES_APP)-deployment.yml) | \
       $(KUBECTL_CMD) apply $(KUBECTL_SCHEMA_CACHE_DIR) -f -
-	@$(KUBECTL_CMD) annotate deployment $(KUBERNETES_APP) 'kubernetes.io/change-cause=$(KUBERNETES_ANNOTATION)'
+	@$(KUBECTL_CMD) annotate deployment $(KUBERNETES_APP) "'kubernetes.io/change-cause=$(KUBERNETES_ANNOTATION)'"
 
 ## Rollback to previous deployment
 kubernetes\:undo-deployment:

--- a/modules/Makefile.kubernetes
+++ b/modules/Makefile.kubernetes
@@ -101,8 +101,8 @@ kubernetes\:delete-deployment:
 kubernetes\:apply-deployment:
 	@echo -e "INFO: Applying updates to $(KUBERNETES_APP) deployment on cluster $(call yellow,$(CLUSTER_NAMESPACE))..."
 	@$(call envsubst,$(KUBERNETES_RESOURCE_PATH)/$(KUBERNETES_APP)-deployment.yml) | \
-      $(KUBECTL_CMD) apply --record=false $(KUBECTL_SCHEMA_CACHE_DIR) -f -
-	@$(KUBECTL_CMD) annotate deployment $(KUBERNETES_APP) kubernetes.io/change-cause="$(KUBERNETES_ANNOTATION)"
+      $(KUBECTL_CMD) apply $(KUBECTL_SCHEMA_CACHE_DIR) -f -
+	@$(KUBECTL_CMD) annotate deployment $(KUBERNETES_APP) 'kubernetes.io/change-cause=$(KUBERNETES_ANNOTATION)'
 
 ## Rollback to previous deployment
 kubernetes\:undo-deployment:

--- a/modules/Makefile.kubernetes
+++ b/modules/Makefile.kubernetes
@@ -3,6 +3,7 @@ CLUSTER_DOMAIN ?= mertslounge.ca
 CLUSTER_BASTION ?= bastion.$(CLUSTER_NAMESPACE).$(CLUSTER_DOMAIN)
 export CLUSTER_NAMESPACE
 
+KUBERNETES_ANNOTATION ?= $(shell date -u +'%Y-%m-%d %H:%M:%SZ')
 KUBERNETES_APP ?= $(subst -docker,,$(shell basename "`pwd`"))
 KUBERNETES_RESOURCE_PATH ?= ./kubernetes
 export KUBERNETES_APP
@@ -101,6 +102,7 @@ kubernetes\:apply-deployment:
 	@echo -e "INFO: Applying updates to $(KUBERNETES_APP) deployment on cluster $(call yellow,$(CLUSTER_NAMESPACE))..."
 	@$(call envsubst,$(KUBERNETES_RESOURCE_PATH)/$(KUBERNETES_APP)-deployment.yml) | \
       $(KUBECTL_CMD) apply --record=false $(KUBECTL_SCHEMA_CACHE_DIR) -f -
+	@$(KUBECTL_CMD) annotate deployment $(KUBERNETES_APP) kubernetes.io/change-cause="$(KUBERNETES_ANNOTATION)"
 
 ## Rollback to previous deployment
 kubernetes\:undo-deployment:


### PR DESCRIPTION
## what 
* annotate latest deployment

## why 
* make it easier to know what a kubernetes `REVISION` corresponds to

## who
@darend 

## inconsistent output
First annotation always work correctly:

![image](https://cloud.githubusercontent.com/assets/52489/15265049/aca66f52-1930-11e6-9477-5d0c66777ffb.png)


Subsequent annotations will look like this:
![image](https://cloud.githubusercontent.com/assets/52489/15265039/6921ef54-1930-11e6-83a3-7b4f605f824a.png)



