### PR TITLE
Assert `IMAGE_TAG` is set

### DIFF
--- a/modules/Makefile.circleci
+++ b/modules/Makefile.circleci
@@ -46,6 +46,7 @@ circle\:release:
 
 ## Deploy to kubernetes after obtaining an exclusive lock
 circle\:deploy-kubernetes:
+	$(call assert,IMAGE_TAG)
 	$(call assert,CIRCLE_BRANCH)
 	$(SELF) circle:tag kubernetes:info
 	@if [ -z "$(CIRCLE_TOKEN)" ]; then \


### PR DESCRIPTION
## what
* Check that the environment variable `IMAGE_TAG` is set

## why
* all kubernetes deployments use this variable in the resource definition

## who
@darend 

DEV-5356