### PR TITLE
Only tag if we built an image

### DIFF
--- a/modules/Makefile.circleci
+++ b/modules/Makefile.circleci
@@ -47,7 +47,8 @@ circle\:release:
 ## Deploy to kubernetes after obtaining an exclusive lock
 circle\:deploy-kubernetes:
 	$(call assert,CIRCLE_BRANCH)
-	$(SELF) circle:tag kubernetes:info
+	@[ ! -f "$(DOCKER_FILE)" ] || $(SELF) circle:tag 
+	@$(SELF) kubernetes:info
 	@if [ -z "$(CIRCLE_TOKEN)" ]; then \
 	echo -e "$(call red,WARN:) Deploying $(RELEASE) without obtaining lock; CIRCLE_TOKEN not defined"; \
 	$(SELF) kubernetes:deploy KUBERNETES_ANNOTATION="$(RELEASE): $(BUILD) - $(COMMIT_LOG) ($(COMMIT))"; \


### PR DESCRIPTION
## what
* check if there is a `DOCKER_FILE` before trying to do compulsory tag

## why
* not everything deployed with `circle:deploy-kubernetes` will be a docker image built by the current project (e.g. `statsd-docker`)

## who
@darend 