### PR TITLE
WIP: tag docker images with git hash

### DIFF
--- a/modules/Makefile.circleci
+++ b/modules/Makefile.circleci
@@ -30,6 +30,7 @@ circle\:tag:
 	@$(SELF) docker:login
 	@echo "INFO: Tagging $(BUILD)"
 	@$(SELF) DOCKER_TAG=$(BUILD) docker:tag docker:push
+	@$(SELF) DOCKER_TAG=$(shell git rev-parse HEAD) docker:tag docker:push
 
 ## Tag as latest and push to registry (CircleCI)
 circle\:tag-latest:

--- a/modules/Makefile.circleci
+++ b/modules/Makefile.circleci
@@ -30,7 +30,7 @@ circle\:tag:
 	@$(SELF) docker:login
 	@echo "INFO: Tagging $(BUILD)"
 	@$(SELF) DOCKER_TAG=$(BUILD) docker:tag docker:push
-	@$(SELF) DOCKER_TAG=$(shell git rev-parse HEAD) docker:tag docker:push
+	@$(SELF) docker:tag-git-hash docker:push
 
 ## Tag as latest and push to registry (CircleCI)
 circle\:tag-latest:

--- a/modules/Makefile.docker
+++ b/modules/Makefile.docker
@@ -87,6 +87,14 @@ docker\:pull: env
 	@echo "INFO: Pulling $(DOCKER_URI)"
 	@$(DOCKER_CMD) pull "$(DOCKER_URI)"
 
+## Pull down the docker image corresponding to the current git hash
+docker\:pull-git-hash:
+	@$(SELF) docker:pull DOCKER_TAG=$(shell git rev-parse HEAD)
+
+## Tag the current docker image with the current git hash
+docker\:tag-git-hash:
+	@$(SELF) docker:tag DOCKER_TAG=$(shell git rev-parse HEAD)
+
 docker\:test:
 	@$(DOCKER_CMD) version 2>&1 >/dev/null | grep 'Error response from daemon'; [ $$? -ne 0 ]
 	@echo "OK"


### PR DESCRIPTION
## what
* Tag all images with their corresponding git hash

## why
* Make it easy to pull down any docker image associated with a git hash for the purposes of re-tagging

## who
@jeremymailen 
cc: @darend 