### PR TITLE
Move deps where they belong

### DIFF
--- a/bin/circleci.sh
+++ b/bin/circleci.sh
@@ -13,12 +13,4 @@ fi
 git clone -b $BUILD_HARNESS_BRANCH $GITHUB_REPO
 make -C $BUILD_HARNESS_PROJECT deps circle:deps
 
-# because as of 2016-04-25, the Ubuntu 14 (experimental) version
-# of CircleCI doesn't have it and it's needed for circle-do-exclusively.sh
-which jq >/dev/null
-if [ $? -ne 0 ]; then                                                                                                                                                                                                                                                                                                                                                     
-  sudo curl -s -q -L https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 -o /usr/local/bin/jq 
-  sudo chown ubuntu:ubuntu /usr/local/bin/jq
-  sudo chmod 755 /usr/local/bin/jq
-fi
 

--- a/modules/Makefile.circleci
+++ b/modules/Makefile.circleci
@@ -23,6 +23,14 @@ circle\:deps:
 	@echo "INFO: Installing Docker $(DOCKER_VERSION)"
 	@sudo curl -s -o $(DOCKER_CMD) $(DOCKER_DOWNLOAD_URL)
 	@sudo chmod 755 $(DOCKER_CMD)
+# because as of 2016-04-25, the Ubuntu 14 (experimental) version
+# of CircleCI doesn't have it and it's needed for circle-do-exclusively.sh
+	@which jq >/dev/null; \
+   if [ $? -ne 0 ]; then \
+     sudo curl -s -q -L https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 -o /usr/local/bin/jq ; \
+     sudo chown ubuntu:ubuntu /usr/local/bin/jq; \
+     sudo chmod 755 /usr/local/bin/jq; \
+  fi
 
 ## Tag using BUILD version and push to registry (CircleCI)
 circle\:tag:

--- a/modules/Makefile.circleci
+++ b/modules/Makefile.circleci
@@ -26,7 +26,7 @@ circle\:deps:
 # because as of 2016-04-25, the Ubuntu 14 (experimental) version
 # of CircleCI doesn't have it and it's needed for circle-do-exclusively.sh
 	@which jq >/dev/null; \
-   if [ $? -ne 0 ]; then \
+   if [ $$? -ne 0 ]; then \
      sudo curl -s -q -L https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 -o /usr/local/bin/jq ; \
      sudo chown ubuntu:ubuntu /usr/local/bin/jq; \
      sudo chmod 755 /usr/local/bin/jq; \


### PR DESCRIPTION
## what
* The `jq` dep should be installed with `make circle:deps`

## why
* If `build-harness` is installed outside of `circleci.sh` (e.g. via a submodule) we still need all deps installed by calling `circle:deps`
* Needed to `releases` project which needs to use submodules (but will be based on `master` @ `HEAD`) because `release-harness` needs to be private (see https://circleci.com/docs/configuration/#checkout)

## who
@darend 