### PR TITLE
support multiple notification modes

### DIFF
--- a/modules/datadog/Makefile
+++ b/modules/datadog/Makefile
@@ -5,11 +5,12 @@
 
 CURL := curl --silent -X POST -H "Content-type: application/json" -d @- 'https://app.datadoghq.com/api/v1/events?api_key=$(DATADOG_API_KEY)' > /dev/null
 
-NOTIFY_SUCCESS ?= @$(SELF) datadog:notify-deploy-success
-NOTIFY_FAILURE ?= ($(SELF) datadog:notify-deploy-failure; exit 1)
-NOTIFY_STARTING ?= @$(SELF) datadog:notify-deploy-starting
+NOTIFY_MODE ?= deploy
+NOTIFY_SUCCESS ?= @$(SELF) datadog:notify-$(NOTIFY_MODE)-success
+NOTIFY_FAILURE ?= ($(SELF) datadog:notify-$(NOTIFY_MODE)-failure; exit 1)
+NOTIFY_STARTING ?= @$(SELF) datadog:notify-$(NOTIFY_MODE)-starting
 
-define datadog_notify
+define datadog_notify_deploy
 	$(call assert,KUBERNETES_APP)
 	$(call assert,DATADOG_API_KEY)
 	$(call assert,CLUSTER_NAMESPACE)
@@ -19,14 +20,46 @@ define datadog_notify
 	@envsubst < $(MAKEFILE_DIR)/modules/datadog/$(1).json | $(CURL)
 endef
 
-## Notify datadog a deploy is starting
+## Notify datadog of a deploy is starting
 datadog\:notify-deploy-starting:
-	$(call datadog_notify,$(subst datadog:notify-,,$@))
+	$(call datadog_notify_deploy,$(subst datadog:notify-,,$@))
 
-## datadog datadog a deploy was successful
+## Notify datadog of a deploy was successful
 datadog\:notify-deploy-success:
-	$(call datadog_notify,$(subst datadog:notify-,,$@))
+	$(call datadog_notify_deploy,$(subst datadog:notify-,,$@))
 
-## datadog datadog a deploy failure
+## Notify datadog of a deploy failure
 datadog\:notify-deploy-failure:
-	$(call datadog_notify,$(subst datadog:notify-,,$@))
+	$(call datadog_notify_deploy,$(subst datadog:notify-,,$@))
+
+define datadog_notify_release
+	$(call assert,KUBERNETES_APP)
+	$(call assert,DATADOG_API_KEY)
+	$(call assert,CLUSTER_NAMESPACE)
+	$(call assert,IMAGE_TAG)
+	@envsubst < $(MAKEFILE_DIR)/modules/datadog/$(1).json | $(CURL)
+endef
+
+## Notify datadog of a release is starting
+datadog\:notify-release-starting:
+	$(call datadog_notify_release,$(subst datadog:notify-,,$@))
+
+## Notify datadog of a release was successful
+datadog\:notify-release-success:
+	$(call datadog_notify_release,$(subst datadog:notify-,,$@))
+
+## Notify datadog of a release failure
+datadog\:notify-release-failure:
+	$(call datadog_notify_release,$(subst datadog:notify-,,$@))
+
+## Notify stdout of a release is starting
+datadog\:notify-stdout-starting:
+	@echo "INFO: Rollout of $(KUBERNETES_APP):$(IMAGE_TAG) to $(CLUSTER_NAMESPACE) starting."
+
+## Notify stdout of a release was successful
+datadog\:notify-stdout-success:
+	@echo "INFO: Rollout of $(KUBERNETES_APP):$(IMAGE_TAG) to $(CLUSTER_NAMESPACE) successful."
+
+## Notify stdout of a release failure
+datadog\:notify-stdout-failure:
+	@echo "INFO: Rollout of $(KUBERNETES_APP):$(IMAGE_TAG) to $(CLUSTER_NAMESPACE) failed."

--- a/modules/datadog/release-failure.json
+++ b/modules/datadog/release-failure.json
@@ -1,0 +1,9 @@
+{
+  "title": "Failed to release $KUBERNETES_APP:$IMAGE_TAG to $CLUSTER_NAMESPACE",
+  "text": "Failed to release $KUBERNETES_APP:$IMAGE_TAG to $CLUSTER_NAMESPACE",
+  "priority": "normal",
+  "tags": ["namespace:$CLUSTER_NAMESPACE","app:$KUBERNETES_APP","image:$IMAGE_TAG"],
+  "alert_type": "error",
+  "source_type_name": "release",
+  "aggregation_key": "$CLUSTER_NAMESPACE-$KUBERNETES_APP-$IMAGE_TAG"
+}

--- a/modules/datadog/release-starting.json
+++ b/modules/datadog/release-starting.json
@@ -1,0 +1,10 @@
+{
+  "title": "Releasing $KUBERNETES_APP:$IMAGE_TAG to $CLUSTER_NAMESPACE",
+  "text": "Releasing $KUBERNETES_APP:$IMAGE_TAG to $CLUSTER_NAMESPACE",
+  "priority": "normal",
+  "tags": ["namespace:$CLUSTER_NAMESPACE","app:$KUBERNETES_APP","image:$IMAGE_TAG"],
+  "alert_type": "info",
+  "source_type_name": "release",
+  "aggregation_key": "$CLUSTER_NAMESPACE-$KUBERNETES_APP-$IMAGE_TAG"
+}
+

--- a/modules/datadog/release-success.json
+++ b/modules/datadog/release-success.json
@@ -1,0 +1,9 @@
+{
+  "title": "Released $KUBERNETES_APP:$IMAGE_TAG to $CLUSTER_NAMESPACE",
+  "text": "Released $KUBERNETES_APP:$IMAGE_TAG to $CLUSTER_NAMESPACE",
+  "priority": "normal",
+  "tags": ["namespace:$CLUSTER_NAMESPACE","app:$KUBERNETES_APP","image:$IMAGE_TAG"],
+  "alert_type": "success",
+  "source_type_name": "release",
+  "aggregation_key": "$CLUSTER_NAMESPACE-$KUBERNETES_APP-$IMAGE_TAG"
+}


### PR DESCRIPTION
## what
* support different forms of notifications
* support notifications to `stdout`
* support release-type notifications which don't have `CIRCLE_*` ENVs.

## why
* the `release-harness` may be used to deploy to clusters where we don't want to notify datadog

## who
@darend 
