### PR TITLE
git tag latest

### DIFF
--- a/modules/Makefile.circleci
+++ b/modules/Makefile.circleci
@@ -45,6 +45,8 @@ circle\:tag-latest:
 	@$(SELF) docker:login
 	@echo "INFO: Tagging latest"
 	@$(SELF) DOCKER_TAG=latest docker:push
+	@git tag --force "$(CIRCLE_BRANCH)-docker-latest"
+	@git push origin --force "tags/$(CIRCLE_BRANCH)-docker-latest"
 
 ## Tag and push official release to registry (CircleCI)
 circle\:release:


### PR DESCRIPTION
## what
* when ever we tag the latest docker image, we should tag the git hash corresponds to it.

## why
* so we can retag the latest docker image so that the staging release process can use it to retag images as `staging`

## who
@jeremymailen 