### PR TITLE
Fetch tags before updating master-docker-latest

### DIFF
--- a/modules/Makefile.circleci
+++ b/modules/Makefile.circleci
@@ -45,6 +45,7 @@ circle\:tag-latest:
 	@$(SELF) docker:login
 	@echo "INFO: Tagging latest"
 	@$(SELF) DOCKER_TAG=latest docker:push
+	@git fetch --tags
 	@git tag --force "$(CIRCLE_BRANCH)-docker-latest"
 	@git push origin --force "tags/$(CIRCLE_BRANCH)-docker-latest"
 


### PR DESCRIPTION
**What**
Add `get fetch --tags` before tagging a repo with `master-docker-latest`

**Why**
So that the locally created tag matches the remote one

**Who**
@jeremymailen cc @osterman 