### PR TITLE
Wait for deployment to complete before exiting

### DIFF
--- a/modules/Makefile.kubernetes
+++ b/modules/Makefile.kubernetes
@@ -135,6 +135,7 @@ kubernetes\:delete-deployment:
 # (private) Update existing deployment or create, if necessary
 kubernetes\:apply-deployment:
 	$(call kubectl_apply,deployment)
+	@$(SELF) kubernetes:status
 
 ## Rollback to previous deployment
 kubernetes\:undo-deployment:
@@ -159,6 +160,10 @@ kubernetes\:delete-job:
 kubernetes\:run-job:
 	@$(SELF) kubernetes:delete-job >/dev/null 2>&1 || true
 	$(call kubectl_create,job)
+
+## Output the status of the deployment
+kubernetes\:status:
+	@$(KUBECTL_CMD) rollout status deployment $(KUBERNETES_APP)
 
 ## List deployed replication controllers for app
 kubernetes\:list-rc:

--- a/modules/Makefile.kubernetes
+++ b/modules/Makefile.kubernetes
@@ -15,6 +15,9 @@ KUBECTL_SSH_CMD := ssh -A -o 'BatchMode=yes' -o 'LogLevel=error' -o 'StrictHostK
 # Optionally define an SSH command to use for tunneling kubectl commands
 KUBECTL_SSH_TUNNEL ?= $(KUBECTL_SSH_USER)@$(CLUSTER_BASTION)
 
+# Flag to control whether or not `kubernetes:status` is called on deployments
+KUBECTL_STATUS ?= true
+
 # Serial number optionally used for versioning; select the last 5 characters of unix time (24 character limit to resource names in k8s)
 SERIAL ?= $(shell echo -n $$(date +%s) | tail -c 5)
 export SERIAL
@@ -135,7 +138,7 @@ kubernetes\:delete-deployment:
 # (private) Update existing deployment or create, if necessary
 kubernetes\:apply-deployment:
 	$(call kubectl_apply,deployment)
-	@$(SELF) kubernetes:status
+	@[ "$(KUBECTL_STATUS)" != "true" ] || $(SELF) kubernetes:status
 
 ## Rollback to previous deployment
 kubernetes\:undo-deployment:

--- a/modules/Makefile.kubernetes
+++ b/modules/Makefile.kubernetes
@@ -138,7 +138,7 @@ kubernetes\:delete-deployment:
 # (private) Update existing deployment or create, if necessary
 kubernetes\:apply-deployment:
 	$(call kubectl_apply,deployment)
-	@[ "$(KUBECTL_STATUS)" != "true" ] || $(SELF) kubernetes:status
+	@[ "$(KUBECTL_STATUS)" != "true" ] || time $(SELF) kubernetes:status
 
 ## Rollback to previous deployment
 kubernetes\:undo-deployment:


### PR DESCRIPTION
## what
* `apply-deployment` should wait for a deployment to complete before exiting
* allow feature to be disabled by specifying `KUBECTL_STATUS=false` (enabled by default)

![image](https://cloud.githubusercontent.com/assets/52489/17449596/7bc3f2fc-5b10-11e6-9e05-a220a1c1e4aa.png)


## why
* k8s 1.3 has the native capability to wait for a rollout of a deployment to complete (either success or error)
* when circle reports a deployment is complete, that should imply the code is live (but that's not what we've been doing)
* we currently have an unrealistic understanding of how long it takes for a deployment to be completed; with this change, we will know exactly how long it takes. 
* if a deployment fails, then the subsequent `apply-` calls should not be triggered - or we risk platform instability (e.g. a `-service` config should never be rolled out before a new compatible deployment is online or we risk a prolonged outage - e.g. a healthcheck URL changed)

## caveats
* You may need to add `timeout: 1800` to the `circle.yml`, See: https://circleci.com/docs/configuration/#modifiers for details
* We might initially see more builds fail like this one: https://circleci.com/gh/sagansystems/edge-router/535; I argue this is a *good* thing, b/c prior to this I had no idea that my rollout was taking so long. I bumped up `timeout: 1800` and then it worked (https://circleci.com/gh/sagansystems/edge-router/536 -albeit this time it took less than 10 minutes). It's good to know what the upper limit might be. Additionally, a rollout can take an indefinite amount of time to complete if there is insufficient capacity. 
* This will slow down the `release-harness` deployment process as deployments will take as long as it takes to become operational.

## who
@darend 
cc: @jeremymailen 