### PR TITLE
Support validation of any kubernetes resource file

### DIFF
--- a/modules/Makefile.kubernetes
+++ b/modules/Makefile.kubernetes
@@ -6,6 +6,7 @@ export CLUSTER_NAMESPACE
 KUBERNETES_ANNOTATION ?= $(shell date -u +'%Y-%m-%d %H:%M:%SZ')
 KUBERNETES_APP ?= $(subst -docker,,$(shell basename "`pwd`"))
 KUBERNETES_RESOURCE_PATH ?= ./kubernetes
+KUBERNETES_RESOURCE_VALIDATION ?= configmap
 export KUBERNETES_APP
 
 # Kubectl specific settings
@@ -76,9 +77,9 @@ kubernetes\:info:
 
 # (private) Validate a configuration
 kubernetes\:validate:
-	@for env in $$(grep -Eo '\$$[A-Z_0-9]+' $(KUBERNETES_RESOURCE_PATH)/$(KUBERNETES_APP)-configmap.yml | cut -d\$$ -f2); do \
+	@for env in $$(grep -Eo '\$$[A-Z_0-9]+' $(KUBERNETES_RESOURCE_PATH)/$(KUBERNETES_APP)-$(KUBERNETES_RESOURCE_VALIDATION).yml | cut -d\$$ -f2); do \
     if [ -z "$${!env}" ]; then \
-      echo "$$env not defined in $(KUBERNETES_RESOURCE_PATH)/$(KUBERNETES_APP)-configmap.yml"; \
+      echo "$$env not defined in $(KUBERNETES_RESOURCE_PATH)/$(KUBERNETES_APP)-$(KUBERNETES_RESOURCE_VALIDATION).yml"; \
       exit 1; \
     fi; \
   done
@@ -151,12 +152,17 @@ kubernetes\:deploy:
 	@[ ! -f "$(KUBERNETES_RESOURCE_PATH)/$(KUBERNETES_APP)-horizontalpodautoscaler.yml" ] || $(SELF) kubernetes:apply-horizontalpodautoscaler || $(NOTIFY_FAILURE)
 	$(NOTIFY_SUCCESS)
 
+# (private) Validate a job
+kubernetes\:validate-job:
+	@$(SELF) kubernetes:validate KUBERNETES_RESOURCE_VALIDATION=job
+
 # (private) Delete a job
 kubernetes\:delete-job:
 	$(call kubectl_delete,job)
 
 ## Run a job
 kubernetes\:run-job:
+	@$(SELF) kubernetes:validate-job
 	@$(SELF) kubernetes:delete-job >/dev/null 2>&1 || true
 	$(call kubectl_create,job)
 


### PR DESCRIPTION
## what
* expose a new variable `KUBERNETES_RESOURCE_VALIDATION` to specify what should be validated on a call to `kubernetes:validate`
* define a new target called `kubernetes:validate-job` that makes sure interpolated environment variables are defined
* make `kubernetes:validate-job` a requirement for `kubernetes:run-job`

## why
* primarily to allow `IMAGE_TAG` to be defined for jobs and make sure they are defined

## who
* @jeremymailen

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sagansystems/build-harness/38)
<!-- Reviewable:end -->
