### PR TITLE
Add kubernetes:job-logs target

### DIFF
--- a/modules/Makefile.kubernetes
+++ b/modules/Makefile.kubernetes
@@ -50,6 +50,10 @@ define kubectl_delete
 	@$(call envsubst,$(KUBERNETES_RESOURCE_PATH)/$(KUBERNETES_APP)-$(1).yml) | $(KUBECTL_CMD) delete --ignore-not-found=true -f -
 endef
 
+define kubectl_job_logs
+	@$(KUBECTL_CMD) logs -f $(shell $(KUBECTL_CMD) get pods -a -o name | grep $(KUBERNETES_APP))
+endef
+
 ifeq ($(CIRCLECI),true)
   KUBECTL_SSH_CMD += -i '$(HOME)/.ssh/id_circleci_github'
   KUBECTL_SSH_USER ?= saganbot
@@ -163,6 +167,10 @@ kubernetes\:delete-job:
 kubernetes\:run-job:
 	@$(SELF) kubernetes:delete-job >/dev/null 2>&1 || true
 	$(call kubectl_create,job)
+
+## Show job logs
+kubernetes\:job-logs:
+	$(call kubectl_job_logs)
 
 ## Output the status of the deployment
 kubernetes\:status:

--- a/modules/Makefile.kubernetes
+++ b/modules/Makefile.kubernetes
@@ -50,10 +50,6 @@ define kubectl_delete
 	@$(call envsubst,$(KUBERNETES_RESOURCE_PATH)/$(KUBERNETES_APP)-$(1).yml) | $(KUBECTL_CMD) delete --ignore-not-found=true -f -
 endef
 
-define kubectl_job_logs
-	@$(KUBECTL_CMD) logs -f $(shell $(KUBECTL_CMD) get pods -a -o name | grep $(KUBERNETES_APP))
-endef
-
 ifeq ($(CIRCLECI),true)
   KUBECTL_SSH_CMD += -i '$(HOME)/.ssh/id_circleci_github'
   KUBECTL_SSH_USER ?= saganbot
@@ -170,7 +166,8 @@ kubernetes\:run-job:
 
 ## Show job logs
 kubernetes\:job-logs:
-	$(call kubectl_job_logs)
+	@echo -e "INFO: Job logs for $(KUBERNETES_APP) on cluster $(call yellow,$(CLUSTER_NAMESPACE))..."
+	@$(KUBECTL_CMD) logs -f $(shell $(KUBECTL_CMD) get pods -a -o name | grep $(KUBERNETES_APP))
 
 ## Output the status of the deployment
 kubernetes\:status:


### PR DESCRIPTION
**Why**
Support running jobs and getting their logs during/after run

**What**
- Added kubernetes:job-logs target

**Testing**
Ran following:
Jeremys-MacBook-Pro:supernova jeremymailen$ CLUSTER_NAMESPACE=master CLUSTER_DOMAIN=mertslounge.ca make kubernetes:job-logs KUBERNETES_APP=supernova-migrate-db

_db/migrate.sh: line 30: warning: here-document at line 25 delimited by end-of-file (wanted `EOF')
migrating ddl_template
goose: no migrations to run. current version: 20160816124834
migrating org_focGBipwG02WhWdvTosMKA
goose: no migrations to run. current version: 20160816124834
migrating org_importtest
goose: no migrations to run. current version: 20160816124834
migrating org_kCBXrgp3n0iNQxgLDx53ug
goose: no migrations to run. current version: 20160816124834
goose: no migrations to run. current version: 20160601134828
generation of create_schema_proc.sh complete
loading of create_schema function with latest DDL complete
migration process complete

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sagansystems/build-harness/39)
<!-- Reviewable:end -->
