### PR TITLE
Fix kubernetes job logging to wait until container ready to provide logs

### DIFF
--- a/modules/Makefile.kubernetes
+++ b/modules/Makefile.kubernetes
@@ -166,12 +166,13 @@ kubernetes\:run-job:
 
 ## Show job logs
 kubernetes\:job-logs:
-	@echo -e "INFO: Job logs for $(KUBERNETES_APP) on cluster $(call yellow,$(CLUSTER_NAMESPACE))..."
+	@echo -e "INFO: Waiting for job $(KUBERNETES_APP) to start on cluster $(call yellow,$(CLUSTER_NAMESPACE))..."
 	@while [[ $$JOB_STATUS != "Running" && $$JOB_STATUS != "Completed" && $$JOB_STATUS != "Failed" ]]; do \
 	sleep 1;\
 	JOB_STATUS=`$(KUBECTL_CMD) get pods -a --no-headers -l job-name=$(KUBERNETES_APP) | tr -s ' ' | cut -d ' ' -f3`;\
 	echo "Job Status = $$JOB_STATUS";\
 	done
+	@echo -e "INFO: Job logs for $(KUBERNETES_APP) on cluster $(call yellow,$(CLUSTER_NAMESPACE)):\n"
 	@$(KUBECTL_CMD) logs -f $(shell $(KUBECTL_CMD) get pods -a -l job-name=$(KUBERNETES_APP) -o name)
 
 ## Output the status of the deployment

--- a/modules/Makefile.kubernetes
+++ b/modules/Makefile.kubernetes
@@ -167,7 +167,12 @@ kubernetes\:run-job:
 ## Show job logs
 kubernetes\:job-logs:
 	@echo -e "INFO: Job logs for $(KUBERNETES_APP) on cluster $(call yellow,$(CLUSTER_NAMESPACE))..."
-	@$(KUBECTL_CMD) logs -f $(shell $(KUBECTL_CMD) get pods -a -o name | grep $(KUBERNETES_APP))
+	@while [[ $$JOB_STATUS != "Running" && $$JOB_STATUS != "Completed" && $$JOB_STATUS != "Failed" ]]; do \
+	sleep 1;\
+	JOB_STATUS=`$(KUBECTL_CMD) get pods -a --no-headers -l job-name=$(KUBERNETES_APP) | tr -s ' ' | cut -d ' ' -f3`;\
+	echo "Job Status = $$JOB_STATUS";\
+	done
+	@$(KUBECTL_CMD) logs -f $(shell $(KUBECTL_CMD) get pods -a -l job-name=$(KUBERNETES_APP) -o name)
 
 ## Output the status of the deployment
 kubernetes\:status:


### PR DESCRIPTION
**Why**
Because it will fail otherwise

**What**
- Add while loop on getting the job pod state
- Minor adjustment to query on job-name rather than grep

**Testing**
- `CLUSTER_NAMESPACE=master CLUSTER_DOMAIN=mertslounge.ca IMAGE_TAG=latest make kubernetes:run-job kubernetes:job-logs KUBERNETES_APP=supernova-migrate-db`
- Verify it waits then outputs the migration result