### PR TITLE
Add kubernetes run job target for circleci

### DIFF
--- a/modules/Makefile.circleci
+++ b/modules/Makefile.circleci
@@ -81,6 +81,7 @@ circle\:run-job-kubernetes:
 	  echo -e "$(call red,WARN:) Running $(JOB_KUBERNETES_APP):$(IMAGE_TAG) without obtaining lock; CIRCLE_TOKEN not defined"; \
 	  $(SELF) kubernetes:run-job kubernetes:job-logs KUBERNETES_APP=$(JOB_KUBERNETES_APP); \
 	else \
-	  echo "INFO: Running $(JOB_KUBERNETES_APP):$(IMAGE_TAG)";
+	  echo "INFO: Running $(JOB_KUBERNETES_APP):$(IMAGE_TAG)"; \
 	  $(MAKEFILE_DIR)/bin/circle-do-exclusively,sh --branch $(CIRCLE_BRANCH) $(SELF) kubernetes:run-job kubernetes:job-logs KUBERNETES_APP=$(JOB_KUBERNETES_APP); \
 	fi
+

--- a/modules/Makefile.circleci
+++ b/modules/Makefile.circleci
@@ -71,3 +71,16 @@ circle\:deploy-kubernetes:
   fi
 	@sleep 3
 	@$(SELF) kubernetes:list-deployments kubernetes:list-rs kubernetes:list-pods
+
+## Run job on kubernetes after obtaining an exclusive lock
+circle\:run-job-kubernetes:
+	$(call assert,IMAGE_TAG)
+	$(call assert,JOB_KUBERNETES_APP)
+	$(call assert,CIRCLE_BRANCH)
+	@if [ -z "$(CIRCLE_TOKEN)" ]; then \
+	  echo -e "$(call red,WARN:) Running $(JOB_KUBERNETES_APP):$(IMAGE_TAG) without obtaining lock; CIRCLE_TOKEN not defined"; \
+	  $(SELF) kubernetes:run-job kubernetes:job-logs KUBERNETES_APP=$(JOB_KUBERNETES_APP); \
+	else \
+	  echo "INFO: Running $(JOB_KUBERNETES_APP):$(IMAGE_TAG)";
+	  $(MAKEFILE_DIR)/bin/circle-do-exclusively,sh --branch $(CIRCLE_BRANCH) $(SELF) kubernetes:run-job kubernetes:job-logs KUBERNETES_APP=$(JOB_KUBERNETES_APP); \
+	fi


### PR DESCRIPTION
**Why**
Provide a mechanism for running supernova db migrations during CD to master

**What**
- circle:run-job-kubernetes target
- Runs job exclusively in parallel circle
- Accepts a JOB_KUBERNETES_APP param as to not conflict with the existing KUBERNETES_APP used for deploy

**Testing**
- Use in a canary branch for supernova first as a test only PR
- Make sure it passes
- Should be safe to deploy a branch off master to master cluster since DB migrations idempotent and don't get checked in every day.

JIRA: [DEV-7142](https://jira.sagansystems.com/browse/DEV-7142)