### PR TITLE
Make kubernetes:job-logs exit with job's exit code

### DIFF
--- a/modules/Makefile.kubernetes
+++ b/modules/Makefile.kubernetes
@@ -164,7 +164,7 @@ kubernetes\:run-job:
 	@$(SELF) kubernetes:delete-job >/dev/null 2>&1 || true
 	$(call kubectl_create,job)
 
-## Show job logs
+## Show job logs and return job exit code
 kubernetes\:job-logs:
 	@echo -e "INFO: Waiting for job $(KUBERNETES_APP) to start on cluster $(call yellow,$(CLUSTER_NAMESPACE))..."
 	@while [[ $$JOB_STATUS != "Running" && $$JOB_STATUS != "Completed" && $$JOB_STATUS != "Failed" ]]; do \
@@ -174,6 +174,7 @@ kubernetes\:job-logs:
 	done
 	@echo -e "INFO: Job logs for $(KUBERNETES_APP) on cluster $(call yellow,$(CLUSTER_NAMESPACE)):\n"
 	@$(KUBECTL_CMD) logs -f $(shell $(KUBECTL_CMD) get pods -a -l job-name=$(KUBERNETES_APP) -o name)
+	@exit $(shell $(KUBECTL_CMD) get pods -a -l job-name=$(KUBERNETES_APP) -o jsonpath={.items..status.containerStatuses[0]..exitCode})
 
 ## Output the status of the deployment
 kubernetes\:status:


### PR DESCRIPTION
**Why**
So that we can detect if the job succeeded or failed in scripts and circleci

**What**
- Add expression to retrieve the exit code from completed job and return it

**Testing**
- From supernova repo: `CLUSTER_NAMESPACE=master CLUSTER_DOMAIN=mertslounge.ca make kubernetes:job-logs KUBERNETES_APP=supernova-migrate-db && echo $?`