### PR TITLE
Trying once more to get k8s job exit code

### DIFF
--- a/modules/Makefile.kubernetes
+++ b/modules/Makefile.kubernetes
@@ -174,7 +174,7 @@ kubernetes\:job-logs:
 	done
 	@echo -e "INFO: Job logs for $(KUBERNETES_APP) on cluster $(call yellow,$(CLUSTER_NAMESPACE)):\n"
 	@$(KUBECTL_CMD) logs -f $(shell $(KUBECTL_CMD) get pods -a -l job-name=$(KUBERNETES_APP) -o name)
-	@exit $(shell $(KUBECTL_CMD) get pods -a -l job-name=$(KUBERNETES_APP) -o jsonpath={.items..status.containerStatuses[0]..exitCode})
+	@exit `$(KUBECTL_CMD) get pods -a -l job-name=$(KUBERNETES_APP) -o jsonpath={.items..status.containerStatuses[0]..exitCode}`
 
 ## Output the status of the deployment
 kubernetes\:status:


### PR DESCRIPTION
**Why**
Apparently the $(shell ...) syntax was immediately evaluated instead of deferred and we didn't get the completed pod content
https://circleci.com/gh/sagansystems/supernova/9395

**What**
- Change to use standard shell backticks

**Testing**
- CLUSTER_NAMESPACE=master CLUSTER_DOMAIN=mertslounge.ca IMAGE_TAG=latest make kubernetes:run-job kubernetes:job-logs KUBERNETES_APP=supernova-migrate-db && echo $?