### PR TITLE
Allow overwriting existing tags in docker 1.9

### DIFF
--- a/modules/Makefile.docker
+++ b/modules/Makefile.docker
@@ -47,13 +47,13 @@ DOCKER_CONTAINER_NAME ?= test_$(DOCKER_IMAGE)
 DOCKER_BIND_PORT ?= $(RANDOM_PORT):80
 DOCKER_SHELL ?= /bin/bash
 
-# Docker client 
+# Docker client
 DOCKER_CMD ?= $(shell which docker)
 
 # Arguments passed to "docker build"
 DOCKER_BUILD_OPTS ?=
 
-.PHONY : docker\:build docker\:push docker\:pull docker\:clean docker\:run docker\:shell docker\:attach docker\:update docker\:start docker\:stop docker\:rm docker\:logs 
+.PHONY : docker\:build docker\:push docker\:pull docker\:clean docker\:run docker\:shell docker\:attach docker\:update docker\:start docker\:stop docker\:rm docker\:logs
 
 deps::
 	$(call assert_set DOCKER_CMD)
@@ -102,7 +102,7 @@ docker\:test:
 docker\:tag:
 	@$(SELF) deps
 	@echo INFO: Tagging $(DOCKER_REPOSITORY):$(DOCKER_BUILD_TAG) as $(DOCKER_URI)
-	@$(DOCKER_CMD) tag "$(DOCKER_REPOSITORY):$(DOCKER_BUILD_TAG)" "$(DOCKER_URI)"
+	@$(DOCKER_CMD) tag -f "$(DOCKER_REPOSITORY):$(DOCKER_BUILD_TAG)" "$(DOCKER_URI)"
 
 ## Remove existing docker images
 docker\:clean:


### PR DESCRIPTION
## what

Allow overwriting of tags in Docker 1.9

## why

Several repos are going to publish images based on a movable git tag
