### PR TITLE
Remove -f from docker:tag

### DIFF
--- a/modules/Makefile.docker
+++ b/modules/Makefile.docker
@@ -102,7 +102,7 @@ docker\:test:
 docker\:tag:
 	@$(SELF) deps
 	@echo INFO: Tagging $(DOCKER_REPOSITORY):$(DOCKER_BUILD_TAG) as $(DOCKER_URI)
-	@$(DOCKER_CMD) tag -f "$(DOCKER_REPOSITORY):$(DOCKER_BUILD_TAG)" "$(DOCKER_URI)"
+	@$(DOCKER_CMD) tag "$(DOCKER_REPOSITORY):$(DOCKER_BUILD_TAG)" "$(DOCKER_URI)"
 
 ## Remove existing docker images
 docker\:clean:


### PR DESCRIPTION
**What**
Remove `-f` from `docker:tag`

**Why**
Docker 1.12 doesn't support -f in docker tag

**Who**
@jeremymailen cc @osterman 