### PR TITLE
Only force tagging on 1.9.1

### DIFF
--- a/modules/Makefile.docker
+++ b/modules/Makefile.docker
@@ -11,7 +11,6 @@ DOCKER_NAMESPACE ?= sagan
 DOCKER_CLIENT_VERSION = `$(DOCKER_CMD) version --format={{.Client.Version}} 2>/dev/null`
 DOCKER_SERVER_VERSION = `$(DOCKER_CMD) version --format={{.Server.Version}} 2>/dev/null`
 
-
 # These vars are are used by the `login` target.
 DOCKER_EMAIL ?=
 DOCKER_USER ?=
@@ -102,7 +101,11 @@ docker\:test:
 docker\:tag:
 	@$(SELF) deps
 	@echo INFO: Tagging $(DOCKER_REPOSITORY):$(DOCKER_BUILD_TAG) as $(DOCKER_URI)
+ifeq ($(DOCKER_SERVER_VERSION),1.9.1)
 	@$(DOCKER_CMD) tag -f "$(DOCKER_REPOSITORY):$(DOCKER_BUILD_TAG)" "$(DOCKER_URI)"
+else
+	@$(DOCKER_CMD) tag "$(DOCKER_REPOSITORY):$(DOCKER_BUILD_TAG)" "$(DOCKER_URI)"
+endif
 
 ## Remove existing docker images
 docker\:clean:


### PR DESCRIPTION
## what

1.9.1 requires `-f` to overwrite a tag, while 1.10 removed the flag
