### PR TITLE
Fix job-logs exit code race condition

### DIFF
--- a/modules/Makefile.kubernetes
+++ b/modules/Makefile.kubernetes
@@ -180,7 +180,12 @@ kubernetes\:job-logs:
 	done
 	@echo -e "INFO: Job logs for $(KUBERNETES_APP) on cluster $(call yellow,$(CLUSTER_NAMESPACE)):\n"
 	@$(KUBECTL_CMD) logs -f $(shell $(KUBECTL_CMD) get pods -a -l job-name=$(KUBERNETES_APP) -o name)
-	@exit `$(KUBECTL_CMD) get pods -a -l job-name=$(KUBERNETES_APP) -o jsonpath={.items..status.containerStatuses[0]..exitCode}`
+	@num='^[0-9]+$$'; \
+	while ! [[ $$EXIT_CODE =~ $$num ]]; do \
+	sleep 1;\
+	EXIT_CODE=`$(KUBECTL_CMD) get pods -a -l job-name=$(KUBERNETES_APP) -o jsonpath={.items..status.containerStatuses[0]..exitCode}`;\
+	done; \
+	exit $$EXIT_CODE
 
 ## Output the status of the deployment
 kubernetes\:status:


### PR DESCRIPTION
The kubernetes harness is liable to finish executing a job
and query for an exitCode before kubernetes has a chance
to process the job completion and update the status on
the contain.

Fix this by looping until the query for the exit code
returns a numeric value.