### PR TITLE
Use a tunnel while executing kubernetes commands

### DIFF
--- a/modules/Makefile.kubernetes
+++ b/modules/Makefile.kubernetes
@@ -10,12 +10,8 @@ KUBERNETES_RESOURCE_VALIDATION ?= configmap
 export KUBERNETES_APP
 
 # Kubectl specific settings
-SSH_SOCK ?= ~/tmp/kubectl-$(CLUSTER_BASTION)
 KUBECTL ?= /opt/bin/kubectl
 KUBECTL_SCHEMA_CACHE_DIR ?= --schema-cache-dir=.kube/cache
-KUBECTL_SSH_CMD := ssh -S $(SSH_SOCK)
-# Optionally define an SSH command to use for tunneling kubectl commands
-KUBECTL_SSH_TUNNEL ?= $(KUBECTL_SSH_USER)@$(CLUSTER_BASTION)
 
 # Flag to control whether or not `kubernetes:status` is called on deployments
 KUBECTL_STATUS ?= true
@@ -53,7 +49,6 @@ define kubectl_delete
 endef
 
 ifeq ($(CIRCLECI),true)
-  KUBECTL_SSH_CMD += -i '$(HOME)/.ssh/id_circleci_github'
   KUBECTL_SSH_USER ?= saganbot
   CLUSTER_NAMESPACE ?= $(CIRCLE_BRANCH)
 endif
@@ -63,10 +58,19 @@ ifeq ($(strip $(KUBECTL_SSH_USER)),)
 	KUBECTL_SSH_USER = $(shell ssh git@github.com 2>&1 | grep 'successfully authenticated' | cut -d' ' -f2 | cut -d'!' -f1)
 endif
 
+# More kubectl specific settings
+KUBECTL_SSH_TUNNEL ?= $(KUBECTL_SSH_USER)@$(CLUSTER_BASTION)
+KUBECTL_SSH_SOCK ?= /tmp/kubectl-$(KUBECTL_SSH_TUNNEL)
+KUBECTL_SSH_OPTS := -A -o 'LogLevel=error' -o 'StrictHostKeyChecking=no' -o 'UserKnownHostsFile=/dev/null' -S $(KUBECTL_SSH_SOCK)
+KUBECTL_SSH_CMD := ssh $(KUBECTL_SSH_OPTS)
+
 # Add the SSH endpoint to the command; everything after the host is expected to be a remote command
 KUBECTL_SSH_CMD += $(KUBECTL_SSH_TUNNEL)
 
 KUBECTL_CMD ?= $(KUBECTL_SSH_CMD) "$(KUBECTL)" --logtostderr=true --insecure-skip-tls-verify=true
+ifeq ($(CIRCLECI),true)
+  KUBECTL_SSH_CMD += -i '$(HOME)/.ssh/id_circleci_github'
+endif
 
 #
 # Reference Docs:
@@ -75,11 +79,11 @@ KUBECTL_CMD ?= $(KUBECTL_SSH_CMD) "$(KUBECTL)" --logtostderr=true --insecure-ski
 ## Bring up SSH tunnel for kubernetes commands, must be called before executing any targets
 kubernetes\:tunnel-up:
 	@echo "Please authenticate using your MFA device..."
-	@ssh -A -M -S $(SSH_SOCK) -f -N -o 'LogLevel=error' -o 'StrictHostKeyChecking=no' -o 'UserKnownHostsFile=/dev/null' $(KUBECTL_SSH_TUNNEL)
+	@ssh $(KUBECTL_SSH_OPTS) -M -f -N $(KUBECTL_SSH_TUNNEL)
 
 ## Tear down kubernetes SSH tunnel, must be called after executing other targets
 kubernetes\:tunnel-down:
-	@[ -e $(SSH_SOCK) ] && ssh -S $(SSH_SOCK) -O exit $(KUBECTL_SSH_TUNNEL)
+	@[ -e $(KUBECTL_SSH_SOCK) ] && ssh -S $(KUBECTL_SSH_SOCK) -O exit $(KUBECTL_SSH_TUNNEL)
 
 ## Display info about the kubernetes setup
 kubernetes\:info:

--- a/modules/Makefile.kubernetes
+++ b/modules/Makefile.kubernetes
@@ -10,9 +10,10 @@ KUBERNETES_RESOURCE_VALIDATION ?= configmap
 export KUBERNETES_APP
 
 # Kubectl specific settings
+SSH_SOCK ?= ~/tmp/kubectl-$(CLUSTER_BASTION)
 KUBECTL ?= /opt/bin/kubectl
 KUBECTL_SCHEMA_CACHE_DIR ?= --schema-cache-dir=.kube/cache
-KUBECTL_SSH_CMD := ssh -A -o 'LogLevel=error' -o 'StrictHostKeyChecking=no' -o 'UserKnownHostsFile=/dev/null'
+KUBECTL_SSH_CMD := ssh -S $(SSH_SOCK)
 # Optionally define an SSH command to use for tunneling kubectl commands
 KUBECTL_SSH_TUNNEL ?= $(KUBECTL_SSH_USER)@$(CLUSTER_BASTION)
 
@@ -71,6 +72,15 @@ KUBECTL_CMD ?= $(KUBECTL_SSH_CMD) "$(KUBECTL)" --logtostderr=true --insecure-ski
 # Reference Docs:
 #  - https://cloud.google.com/container-engine/docs/kubectl/
 #
+## Bring up SSH tunnel for kubernetes commands, must be called before executing any targets
+kubernetes\:tunnel-up:
+	@echo "Please authenticate using your MFA device..."
+	@ssh -A -M -S $(SSH_SOCK) -f -N -o 'LogLevel=error' -o 'StrictHostKeyChecking=no' -o 'UserKnownHostsFile=/dev/null' $(KUBECTL_SSH_TUNNEL)
+
+## Tear down kubernetes SSH tunnel, must be called after executing other targets
+kubernetes\:tunnel-down:
+	@[ -e $(SSH_SOCK) ] && ssh -S $(SSH_SOCK) -O exit $(KUBECTL_SSH_TUNNEL)
+
 ## Display info about the kubernetes setup
 kubernetes\:info:
 	@echo -e "Cluster Namespace: $(call yellow,$(CLUSTER_NAMESPACE))"


### PR DESCRIPTION
**What**
- Add targets to create/destroy an SSH tunnel for use while executing kubernetes commands

**Why**
This will allow a user to verify via MFA only once

**Context**
See https://github.com/sagansystems/release-harness/pull/58 for use