### PR TITLE
fix case sensitive bug for github usernames

### DIFF
--- a/modules/Makefile.kubernetes
+++ b/modules/Makefile.kubernetes
@@ -55,7 +55,7 @@ endif
 
 ifeq ($(strip $(KUBECTL_SSH_USER)),)
   # Guess their github username
-	KUBECTL_SSH_USER = $(shell ssh git@github.com 2>&1 | grep 'successfully authenticated' | cut -d' ' -f2 | cut -d'!' -f1)
+	KUBECTL_SSH_USER = $(shell ssh git@github.com 2>&1 | grep 'successfully authenticated' | cut -d' ' -f2 | cut -d'!' -f1 | tr A-Z a-z)
 endif
 
 # More kubectl specific settings


### PR DESCRIPTION
## what
* change case to always be lowercase

## why
* multiple bugs occurred because my github username is `AlbertAlquisola` but needs to be reformatted to `albertalquisola`.  With this, it'll be abstracted out and future developers wont have to worry about this case sensitivity issue.

## who
@darend 