### PR TITLE
Use Constant Timestamp

### DIFF
--- a/modules/Makefile.circleci
+++ b/modules/Makefile.circleci
@@ -7,9 +7,11 @@ else
 BUILD ?= $(CIRCLE_BRANCH)-$(CIRCLE_BUILD_NUM)
 endif
 
+# Calculate timestamp exactly once at first evaluation
+TIMESTAMP := $(shell date -u +'%Y%m%d%H%M%SZ')
 COMMIT ?= $(CIRCLE_SHA1)
 COMMIT_LOG ?= $(shell git log --format=oneline --pretty=format:'%s' -n 1 $(CIRCLE_SHA1))
-RELEASE ?= release-$(shell date -u +'%Y%m%d%H%M%SZ')
+RELEASE ?= release-$(TIMESTAMP)
 DOCKER_BUILD_OPTS += --build-arg build=$(BUILD) --build-arg commit=$(COMMIT)
 
 export COMMIT


### PR DESCRIPTION
## what
* Use `:=` assignment for the current timestamp
* Decompose `RELEASE` into a prefix + `TIMESTAMP` (since I believe the `release-harness` might override `RELEASE`)

## why
* The `?=` operator assignment is evaluated at call-time, which means that if the LHS variable is called multiple times throughout a long-running script, the value might change. 
* https://github.com/sagansystems/cloud-platform/pull/424#discussion_r104222908

## who
@darend 
