### PR TITLE
Circle 2.0 Support [Do not merge]

### DIFF
--- a/bin/circleci.sh
+++ b/bin/circleci.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
-export DOCKER_VERSION=${1:-1.9.1}
 export BUILD_HARNESS_PROJECT=${2:-build-harness}
-export BUILD_HARNESS_BRANCH=${3:-master}
+export BUILD_HARNESS_BRANCH=${3:-circle-2.0}
 export GITHUB_REPO="git@github.com:sagansystems/${BUILD_HARNESS_PROJECT}.git"
 
 cd ~

--- a/bin/circleci.sh
+++ b/bin/circleci.sh
@@ -3,7 +3,6 @@ export BUILD_HARNESS_PROJECT=${2:-build-harness}
 export BUILD_HARNESS_BRANCH=${3:-circle-2.0}
 export GITHUB_REPO="git@github.com:sagansystems/${BUILD_HARNESS_PROJECT}.git"
 
-cd ~
 if [ "$BUILD_HARNESS_PROJECT" ] && [ -d "$BUILD_HARNESS_PROJECT" ]; then
 	echo "Removing existing $BUILD_HARNESS_PROJECT"
   rm -rf "$BUILD_HARNESS_PROJECT"

--- a/modules/Makefile.circleci
+++ b/modules/Makefile.circleci
@@ -1,6 +1,3 @@
-DOCKER_DOWNLOAD_URL = https://s3-external-1.amazonaws.com/circle-downloads/docker-$(DOCKER_VERSION)-circleci
-DOCKER_CMD = /usr/bin/docker
-
 ifdef CIRCLE_TAG
 BUILD ?= $(CIRCLE_TAG)
 else
@@ -20,17 +17,6 @@ export RELEASE
 
 ## Install CircleCI deps
 circle\:deps:
-	@echo "INFO: Installing Docker $(DOCKER_VERSION)"
-	@sudo curl -s -o $(DOCKER_CMD) $(DOCKER_DOWNLOAD_URL)
-	@sudo chmod 755 $(DOCKER_CMD)
-# because as of 2016-04-25, the Ubuntu 14 (experimental) version
-# of CircleCI doesn't have it and it's needed for circle-do-exclusively.sh
-	@which jq >/dev/null; \
-   if [ $$? -ne 0 ]; then \
-     sudo curl -s -q -L https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 -o /usr/local/bin/jq ; \
-     sudo chown ubuntu:ubuntu /usr/local/bin/jq; \
-     sudo chmod 755 /usr/local/bin/jq; \
-  fi
 	cat $(MAKEFILE_DIR)/retry.sh >> ~/.bashrc
 
 ## Tag using BUILD version and push to registry (CircleCI)

--- a/modules/Makefile.circleci
+++ b/modules/Makefile.circleci
@@ -22,14 +22,12 @@ circle\:deps:
 ## Tag using BUILD version and push to registry (CircleCI)
 circle\:tag:
 	@$(call assert_set,BUILD)
-	@$(SELF) docker:login
 	@echo "INFO: Tagging $(COMMIT) as $(BUILD)"
 	@$(SELF) DOCKER_TAG=$(BUILD) docker:tag docker:push
 	@$(SELF) DOCKER_TAG=$(COMMIT) docker:tag docker:push
 
 ## Tag as latest and push to registry (CircleCI)
 circle\:tag-latest:
-	@$(SELF) docker:login
 	@echo "INFO: Tagging latest"
 	@$(SELF) DOCKER_TAG=latest docker:push
 	@git fetch --tags
@@ -39,7 +37,6 @@ circle\:tag-latest:
 ## Tag and push official release to registry (CircleCI)
 circle\:release:
 	@$(call assert_set,RELEASE)
-	@$(SELF) docker:login
 	@echo "INFO: Releasing $(RELEASE)"
 	@$(SELF) DOCKER_TAG=$(RELEASE) docker:tag docker:push
 

--- a/modules/Makefile.docker
+++ b/modules/Makefile.docker
@@ -12,7 +12,6 @@ DOCKER_CLIENT_VERSION = $(shell $(DOCKER_CMD) version --format={{.Client.Version
 DOCKER_SERVER_VERSION = $(shell $(DOCKER_CMD) version --format={{.Server.Version}} 2>/dev/null)
 
 # These vars are are used by the `login` target.
-DOCKER_EMAIL ?=
 DOCKER_USER ?=
 DOCKER_PASS ?=
 
@@ -136,11 +135,10 @@ docker\:attach:
 ## Login to docker registry
 docker\:login:
 	@$(SELF) deps
-	@$(call assert_set,DOCKER_EMAIL)
 	@$(call assert_set,DOCKER_USER)
 	@$(call assert_set,DOCKER_PASS)
 	@echo "INFO: Logging in as $(DOCKER_USER)"
-	@$(DOCKER_CMD) login -e $(DOCKER_EMAIL) -u $(DOCKER_USER) -p $(DOCKER_PASS)
+	@$(DOCKER_CMD) login -u $(DOCKER_USER) -p $(DOCKER_PASS)
 
 ## Export docker images to file
 docker\:export:

--- a/modules/Makefile.kubernetes
+++ b/modules/Makefile.kubernetes
@@ -68,9 +68,6 @@ KUBECTL_SSH_CMD := ssh $(KUBECTL_SSH_OPTS)
 KUBECTL_SSH_CMD += $(KUBECTL_SSH_TUNNEL)
 
 KUBECTL_CMD ?= $(KUBECTL_SSH_CMD) "$(KUBECTL)" --logtostderr=true --insecure-skip-tls-verify=true
-ifeq ($(CIRCLECI),true)
-  KUBECTL_SSH_CMD += -i '$(HOME)/.ssh/id_circleci_github'
-endif
 
 #
 # Reference Docs:
@@ -198,6 +195,7 @@ kubernetes\:job-logs:
 	while ! [[ $$EXIT_CODE =~ $$num ]]; do \
 		sleep 1;\
 		EXIT_CODE=`$(KUBECTL_CMD) get pods -a -l job-name=$(KUBERNETES_APP) -o jsonpath={.items..status.containerStatuses[0]..exitCode} 2>&1`;\
+		echo "Found exit code [$$EXIT_CODE] for job $(KUBERNETES_APP)";\
 		if [[ $$EXIT_CODE = "No resources found." ]]; then \
 			echo "failed to find job exit code"; \
 			exit 1; \


### PR DESCRIPTION
## what

Adds Circle 2.0 support at the cost of Circle 1.0 support

## why

Circle 2.0 behaves very differently

## Migration plan

Up for debate, possible approach:

1. Create a circle 1.0 tag and have existing repos use it instead of relying on `latest`
2. Modify legacy repos to use the Circle 1.0 tag
3. Merge change