### PR TITLE
Add Circle 2.0 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,9 +23,12 @@ define assert_set
   @[ -n "$($1)" ] || (echo "$(1) not set in $(@)"; exit 1)
 endef
 
-# Setup the docker run-time environment
 ifeq ($(CIRCLECI),true)
-  include $(MAKEFILE_DIR)/modules/Makefile.circleci
+  ifdef CIRCLE_JOB # Circle 2.0
+      include $(MAKEFILE_DIR)/modules/Makefile.circleci-2.0
+  else
+      include $(MAKEFILE_DIR)/modules/Makefile.circleci-1.0
+  endif
 endif
 
 # Include the docker-specific targets

--- a/bin/circleci.sh
+++ b/bin/circleci.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
-export DOCKER_VERSION=${1:-1.9.1} # only used by Circle 1.0
+if [ -z "$CIRCLE_JOB" ]; then
+  export DOCKER_VERSION=${1:-1.9.1} # only used by Circle 1.0
+fi
+
 export BUILD_HARNESS_PROJECT=${2:-build-harness}
 export BUILD_HARNESS_BRANCH=${3:-master}
 export GITHUB_REPO="git@github.com:sagansystems/${BUILD_HARNESS_PROJECT}.git"

--- a/bin/circleci.sh
+++ b/bin/circleci.sh
@@ -4,7 +4,7 @@ if [ -z "$CIRCLE_JOB" ]; then
 fi
 
 export BUILD_HARNESS_PROJECT=${2:-build-harness}
-export BUILD_HARNESS_BRANCH=${3:-circle-2.0-wip}
+export BUILD_HARNESS_BRANCH=${3:-master}
 export GITHUB_REPO="git@github.com:sagansystems/${BUILD_HARNESS_PROJECT}.git"
 
 # If Circle 1.0 build, install to home directory

--- a/bin/circleci.sh
+++ b/bin/circleci.sh
@@ -4,7 +4,7 @@ if [ -z "$CIRCLE_JOB" ]; then
 fi
 
 export BUILD_HARNESS_PROJECT=${2:-build-harness}
-export BUILD_HARNESS_BRANCH=${3:-master}
+export BUILD_HARNESS_BRANCH=${3:-circle-2.0-wip}
 export GITHUB_REPO="git@github.com:sagansystems/${BUILD_HARNESS_PROJECT}.git"
 
 # If Circle 1.0 build, install to home directory

--- a/bin/circleci.sh
+++ b/bin/circleci.sh
@@ -1,8 +1,13 @@
 #!/bin/bash
-
+export DOCKER_VERSION=${1:-1.9.1} # only used by Circle 1.0
 export BUILD_HARNESS_PROJECT=${2:-build-harness}
 export BUILD_HARNESS_BRANCH=${3:-master}
 export GITHUB_REPO="git@github.com:sagansystems/${BUILD_HARNESS_PROJECT}.git"
+
+# If Circle 1.0 build, install to home directory
+if [ -z "$CIRCLE_JOB" ]; then
+    cd ~
+fi
 
 if [ "$BUILD_HARNESS_PROJECT" ] && [ -d "$BUILD_HARNESS_PROJECT" ]; then
 	echo "Removing existing $BUILD_HARNESS_PROJECT"

--- a/bin/circleci.sh
+++ b/bin/circleci.sh
@@ -1,10 +1,9 @@
 #!/bin/bash
-export DOCKER_VERSION=${1:-1.9.1}
+
 export BUILD_HARNESS_PROJECT=${2:-build-harness}
 export BUILD_HARNESS_BRANCH=${3:-master}
 export GITHUB_REPO="git@github.com:sagansystems/${BUILD_HARNESS_PROJECT}.git"
 
-cd ~
 if [ "$BUILD_HARNESS_PROJECT" ] && [ -d "$BUILD_HARNESS_PROJECT" ]; then
 	echo "Removing existing $BUILD_HARNESS_PROJECT"
   rm -rf "$BUILD_HARNESS_PROJECT"

--- a/modules/Makefile.circleci-1.0
+++ b/modules/Makefile.circleci-1.0
@@ -20,6 +20,9 @@ export RELEASE
 
 .PHONY : circle\:tag circle\:release circle\:deps
 
+circle\:version:
+	@echo "Circle 1.0"
+
 ## Install CircleCI deps
 circle\:deps:
 	@echo "INFO: Installing Docker $(DOCKER_VERSION)"

--- a/modules/Makefile.circleci-1.0
+++ b/modules/Makefile.circleci-1.0
@@ -1,4 +1,4 @@
-export CIRCLE_1.0 = true
+export CIRCLE_VERSION = "1.0"
 
 DOCKER_DOWNLOAD_URL = https://s3-external-1.amazonaws.com/circle-downloads/docker-$(DOCKER_VERSION)-circleci
 DOCKER_CMD = /usr/bin/docker
@@ -22,6 +22,7 @@ export RELEASE
 
 ## Install CircleCI deps
 circle\:deps:
+	@echo "Configuring for Circle ${CIRCLE_VERSION}"
 	@echo "INFO: Installing Docker $(DOCKER_VERSION)"
 	@sudo curl -s -o $(DOCKER_CMD) $(DOCKER_DOWNLOAD_URL)
 	@sudo chmod 755 $(DOCKER_CMD)

--- a/modules/Makefile.circleci-1.0
+++ b/modules/Makefile.circleci-1.0
@@ -20,9 +20,6 @@ export RELEASE
 
 .PHONY : circle\:tag circle\:release circle\:deps
 
-circle\:version:
-	@echo "Circle 1.0"
-
 ## Install CircleCI deps
 circle\:deps:
 	@echo "INFO: Installing Docker $(DOCKER_VERSION)"

--- a/modules/Makefile.circleci-1.0
+++ b/modules/Makefile.circleci-1.0
@@ -1,3 +1,5 @@
+export CIRCLE_1.0 = true
+
 DOCKER_DOWNLOAD_URL = https://s3-external-1.amazonaws.com/circle-downloads/docker-$(DOCKER_VERSION)-circleci
 DOCKER_CMD = /usr/bin/docker
 

--- a/modules/Makefile.circleci-2.0
+++ b/modules/Makefile.circleci-2.0
@@ -1,0 +1,72 @@
+export CIRCLE_2.0 = true
+
+ifdef CIRCLE_TAG
+BUILD ?= $(CIRCLE_TAG)
+else
+BUILD ?= $(CIRCLE_BRANCH)-$(CIRCLE_BUILD_NUM)
+endif
+
+# Calculate timestamp exactly once at first evaluation
+TIMESTAMP := $(shell date -u +'%Y%m%d%H%M%SZ')
+COMMIT ?= $(CIRCLE_SHA1)
+RELEASE ?= release-$(TIMESTAMP)
+DOCKER_BUILD_OPTS += --build-arg build=$(BUILD) --build-arg commit=$(COMMIT)
+
+export COMMIT
+export RELEASE
+
+.PHONY : circle\:tag circle\:release circle\:deps
+
+## Install CircleCI deps
+circle\:deps:
+	cat $(MAKEFILE_DIR)/retry.sh >> ~/.bashrc
+
+## Tag using BUILD version and push to registry (CircleCI)
+circle\:tag:
+	@$(call assert_set,BUILD)
+	@echo "INFO: Tagging $(COMMIT) as $(BUILD)"
+	@$(SELF) DOCKER_TAG=$(BUILD) docker:tag docker:push
+	@$(SELF) DOCKER_TAG=$(COMMIT) docker:tag docker:push
+
+## Tag as latest and push to registry (CircleCI)
+circle\:tag-latest:
+	@echo "INFO: Tagging latest"
+	@$(SELF) DOCKER_TAG=latest docker:push
+	@git fetch --tags
+	@git tag --force "$(CIRCLE_BRANCH)-docker-latest"
+	@git push origin --force "tags/$(CIRCLE_BRANCH)-docker-latest"
+
+## Tag and push official release to registry (CircleCI)
+circle\:release:
+	@$(call assert_set,RELEASE)
+	@echo "INFO: Releasing $(RELEASE)"
+	@$(SELF) DOCKER_TAG=$(RELEASE) docker:tag docker:push
+
+## Deploy to kubernetes after obtaining an exclusive lock
+circle\:deploy-kubernetes:
+	$(call assert,IMAGE_TAG)
+	$(call assert,CIRCLE_BRANCH)
+	@[ ! -f "$(DOCKER_FILE)" ] || $(SELF) circle:tag
+	@$(SELF) kubernetes:info
+	@if [ -z "$(CIRCLE_TOKEN)" ]; then \
+	  echo -e "$(call red,WARN:) Deploying $(IMAGE_TAG) without obtaining lock; CIRCLE_TOKEN not defined"; \
+	  $(SELF) kubernetes:configure kubernetes:deploy KUBERNETES_ANNOTATION="$(RELEASE): $(BUILD) - commit $(COMMIT)"; \
+  else \
+	  echo "INFO: Deploying $(IMAGE_TAG)"; \
+	  $(MAKEFILE_DIR)/bin/circle-do-exclusively.sh --branch $(CIRCLE_BRANCH) $(SELF) kubernetes:configure kubernetes:deploy; \
+  fi
+	@sleep 3
+	@$(SELF) kubernetes:list-deployments kubernetes:list-rs kubernetes:list-pods
+
+## Run job on kubernetes after obtaining an exclusive lock
+circle\:run-job-kubernetes:
+	$(call assert,IMAGE_TAG)
+	$(call assert,JOB_KUBERNETES_APP)
+	$(call assert,CIRCLE_BRANCH)
+	@if [ -z "$(CIRCLE_TOKEN)" ]; then \
+	  echo -e "$(call red,WARN:) Running $(JOB_KUBERNETES_APP):$(IMAGE_TAG) without obtaining lock; CIRCLE_TOKEN not defined"; \
+	  $(SELF) kubernetes:run-job kubernetes:job-logs KUBERNETES_APP=$(JOB_KUBERNETES_APP); \
+	else \
+	  echo "INFO: Running $(JOB_KUBERNETES_APP):$(IMAGE_TAG)"; \
+	  $(MAKEFILE_DIR)/bin/circle-do-exclusively.sh --branch $(CIRCLE_BRANCH) $(SELF) kubernetes:run-job kubernetes:job-logs KUBERNETES_APP=$(JOB_KUBERNETES_APP); \
+	fi

--- a/modules/Makefile.circleci-2.0
+++ b/modules/Makefile.circleci-2.0
@@ -15,9 +15,6 @@ DOCKER_BUILD_OPTS += --build-arg build=$(BUILD) --build-arg commit=$(COMMIT)
 export COMMIT
 export RELEASE
 
-circle\:version:
-	@echo "Circle 2.0"
-
 .PHONY : circle\:tag circle\:release circle\:deps
 
 ## Install CircleCI deps

--- a/modules/Makefile.circleci-2.0
+++ b/modules/Makefile.circleci-2.0
@@ -1,4 +1,4 @@
-export CIRCLE_2.0 = true
+export CIRCLE_VERSION = "2.0"
 
 ifdef CIRCLE_TAG
 BUILD ?= $(CIRCLE_TAG)
@@ -19,7 +19,8 @@ export RELEASE
 
 ## Install CircleCI deps
 circle\:deps:
-	cat $(MAKEFILE_DIR)/retry.sh >> ~/.bashrc
+	@echo "Configuring for Circle ${CIRCLE_VERSION}"
+	@cat $(MAKEFILE_DIR)/retry.sh >> ~/.bashrc
 
 ## Tag using BUILD version and push to registry (CircleCI)
 circle\:tag:

--- a/modules/Makefile.circleci-2.0
+++ b/modules/Makefile.circleci-2.0
@@ -15,6 +15,9 @@ DOCKER_BUILD_OPTS += --build-arg build=$(BUILD) --build-arg commit=$(COMMIT)
 export COMMIT
 export RELEASE
 
+circle\:version:
+	@echo "Circle 2.0"
+
 .PHONY : circle\:tag circle\:release circle\:deps
 
 ## Install CircleCI deps

--- a/modules/Makefile.docker
+++ b/modules/Makefile.docker
@@ -136,11 +136,16 @@ docker\:attach:
 ## Login to docker registry
 docker\:login:
 	@$(SELF) deps
-	@$(call assert_set,DOCKER_EMAIL)
 	@$(call assert_set,DOCKER_USER)
 	@$(call assert_set,DOCKER_PASS)
 	@echo "INFO: Logging in as $(DOCKER_USER)"
-	@$(DOCKER_CMD) login -e $(DOCKER_EMAIL) -u $(DOCKER_USER) -p $(DOCKER_PASS)
+	@docker login --help|grep email
+	if [ $$? -ne 0 ]; then \
+		$(DOCKER_CMD) login -u $(DOCKER_USER) -p $(DOCKER_PASS); \
+	else \
+		$(call assert_set,DOCKER_EMAIL); \
+		$(DOCKER_CMD) login -e $(DOCKER_EMAIL) -u $(DOCKER_USER) -p $(DOCKER_PASS); \
+	fi
 
 ## Export docker images to file
 docker\:export:

--- a/modules/Makefile.docker
+++ b/modules/Makefile.docker
@@ -139,8 +139,7 @@ docker\:login:
 	@$(call assert_set,DOCKER_USER)
 	@$(call assert_set,DOCKER_PASS)
 	$(eval docker_version = $(shell docker version|grep Version | tail -n 1 | tr -s ' ' | cut -d ' ' -f3 | cut -d '.' -f 1 | cut -d . -f1))
-	@echo "Docker Version: ${docker_version}"
-	if [ ${docker_version} -gt 12 ]; then \
+	@if [ ${docker_version} -gt 12 ]; then \
 		echo "INFO: Logging in as $(DOCKER_USER)"; \
 		$(DOCKER_CMD) login -u $(DOCKER_USER) -p $(DOCKER_PASS); \
 	else \

--- a/modules/Makefile.docker
+++ b/modules/Makefile.docker
@@ -138,11 +138,13 @@ docker\:login:
 	@$(SELF) deps
 	@$(call assert_set,DOCKER_USER)
 	@$(call assert_set,DOCKER_PASS)
-	@echo "INFO: Logging in as $(DOCKER_USER)"
-	@docker login --help | grep email
-	if [ $$? -ne 0 ]; then \
+	$(eval docker_version = $(shell docker version|grep Version | tail -n 1 | tr -s ' ' | cut -d ' ' -f3 | cut -d '.' -f 1 | cut -d . -f1))
+	@echo "Docker Version: ${docker_version}"
+	if [ ${docker_version} -gt 12 ]; then \
+		echo "INFO: Logging in as $(DOCKER_USER)"; \
 		$(DOCKER_CMD) login -u $(DOCKER_USER) -p $(DOCKER_PASS); \
 	else \
+		echo "INFO: Logging in as $(DOCKER_USER)/${DOCKER_EMAIL}"; \
 		$(DOCKER_CMD) login -e $(DOCKER_EMAIL) -u $(DOCKER_USER) -p $(DOCKER_PASS); \
 	fi
 

--- a/modules/Makefile.docker
+++ b/modules/Makefile.docker
@@ -139,11 +139,10 @@ docker\:login:
 	@$(call assert_set,DOCKER_USER)
 	@$(call assert_set,DOCKER_PASS)
 	@echo "INFO: Logging in as $(DOCKER_USER)"
-	@docker login --help|grep email
+	@docker login --help | grep email
 	if [ $$? -ne 0 ]; then \
 		$(DOCKER_CMD) login -u $(DOCKER_USER) -p $(DOCKER_PASS); \
 	else \
-		$(call assert_set,DOCKER_EMAIL); \
 		$(DOCKER_CMD) login -e $(DOCKER_EMAIL) -u $(DOCKER_USER) -p $(DOCKER_PASS); \
 	fi
 

--- a/modules/Makefile.kubernetes
+++ b/modules/Makefile.kubernetes
@@ -197,7 +197,9 @@ kubernetes\:job-logs:
 	@num='^[0-9]+$$'; \
 	while ! [[ $$EXIT_CODE =~ $$num ]]; do \
 		sleep 1;\
-		EXIT_CODE=`$(KUBECTL_CMD) get pods -a -l job-name=$(KUBERNETES_APP) -o jsonpath={.items..status.containerStatuses[0]..exitCode} 2>&1`;\
+		EXIT_CODE=`$(KUBECTL_CMD) get pods -a -l job-name=$(KUBERNETES_APP) -o jsonpath=
+		{.items..status.containerStatuses[0]..exitCode} 2>&1`;\
+		echo "Found exit code [$$EXIT_CODE] for job $(KUBERNETES_APP)";\
 		if [[ $$EXIT_CODE = "No resources found." ]]; then \
 			echo "failed to find job exit code"; \
 			exit 1; \

--- a/modules/Makefile.kubernetes
+++ b/modules/Makefile.kubernetes
@@ -68,7 +68,7 @@ KUBECTL_SSH_CMD := ssh $(KUBECTL_SSH_OPTS)
 KUBECTL_SSH_CMD += $(KUBECTL_SSH_TUNNEL)
 
 KUBECTL_CMD ?= $(KUBECTL_SSH_CMD) "$(KUBECTL)" --logtostderr=true --insecure-skip-tls-verify=true
-ifeq ($(CIRCLECI),true)
+ifeq ($(CIRCLE_1.0),true)
   KUBECTL_SSH_CMD += -i '$(HOME)/.ssh/id_circleci_github'
 endif
 


### PR DESCRIPTION
## what

Adds Circle 2.0 support while maintaining 1.0 support

After speaking with Circle they recommended we rely on the `CIRCLE_JOB` flag to indicate the build type. The alternative would be to add a parameter to the `circle.sh` that sets the type of build

## Builds

2.0 Project built using this branch: https://circleci.com/gh/sagansystems/synthetic/574
1.0 Project built using this branch: https://circleci.com/gh/sagansystems/synthetic/572