### PR TITLE
Add circle:cleanup target to remove old docker images

### DIFF
--- a/modules/Makefile.circleci-2.0
+++ b/modules/Makefile.circleci-2.0
@@ -60,7 +60,7 @@ circle\:deploy-kubernetes:
 	@$(SELF) kubernetes:list-deployments kubernetes:list-rs kubernetes:list-pods
 
 ## Cleanup docker images on CircleCI
-circle\:cleanup:
+circle\:cleanup-docker:
 	@echo "INFO: Cleaning up older dangling docker images"
 	@docker images -f "dangling=true" --format "{{.ID}} {{.CreatedSince}}" | grep "weeks ago" | cut -f 1 -d " " | xargs --no-run-if-empty docker rmi || true
 

--- a/modules/Makefile.circleci-2.0
+++ b/modules/Makefile.circleci-2.0
@@ -59,6 +59,11 @@ circle\:deploy-kubernetes:
 	@sleep 3
 	@$(SELF) kubernetes:list-deployments kubernetes:list-rs kubernetes:list-pods
 
+## Cleanup docker images on CircleCI
+circle\:cleanup:
+	@echo "INFO: Cleaning up older dangling docker images"
+	@docker images -f "dangling=true" --format "{{.ID}} {{.CreatedSince}}" | grep "weeks ago" | cut -f 1 -d " " | xargs --no-run-if-empty docker rmi || true
+
 ## Run job on kubernetes after obtaining an exclusive lock
 circle\:run-job-kubernetes:
 	$(call assert,IMAGE_TAG)


### PR DESCRIPTION
### What
Add circle:cleanup target to remove old docker images

### Why
With CircleCI 2.0 reusable cache we have to cleanup docker ourselves

### Who
@darend 