### PR TITLE
Cleanup Docker more aggresively

### DIFF
--- a/modules/Makefile.circleci-2.0
+++ b/modules/Makefile.circleci-2.0
@@ -62,7 +62,7 @@ circle\:deploy-kubernetes:
 ## Cleanup docker images on CircleCI
 circle\:cleanup-docker:
 	@echo "INFO: Cleaning up older dangling docker images"
-	@docker images -f "dangling=true" --format "{{.ID}} {{.CreatedSince}}" | grep "weeks ago" | cut -f 1 -d " " | xargs --no-run-if-empty docker rmi || true
+	@docker images -f "dangling=true" --format "{{.ID}} {{.CreatedSince}}" | grep "days\|weeks" | cut -f 1 -d " " | xargs --no-run-if-empty docker rmi || true
 
 ## Run job on kubernetes after obtaining an exclusive lock
 circle\:run-job-kubernetes:


### PR DESCRIPTION
### What
Cleanup Docker more aggresively

### Why
We stil ocasionally run out of disk space on CI Docker, so cleanup more recent images

### Who
@darend 

### Context
https://circleci.com/gh/sagansystems/agent-desktop/32062
docker save -o ./docker_cache/datasets.tar sagan/datasets:latest
Error response from daemon: write [...]: no space left on device