### PR TITLE
Use smarter garbage collection for circle:cleanup-docker

### DIFF
--- a/modules/Makefile.circleci-2.0
+++ b/modules/Makefile.circleci-2.0
@@ -61,8 +61,8 @@ circle\:deploy-kubernetes:
 
 ## Cleanup docker images on CircleCI
 circle\:cleanup-docker:
-	@echo "INFO: Cleaning up older dangling docker images"
-	@docker images -f "dangling=true" --format "{{.ID}} {{.CreatedSince}}" | grep "days\|weeks" | cut -f 1 -d " " | xargs --no-run-if-empty docker rmi || true
+	@echo "INFO: Running Docker garbage collection"
+	@docker run -e FORCE_IMAGE_REMOVAL=1 -e GRACE_PERIOD_SECONDS=86400 -e MINIMUM_IMAGES_TO_SAVE=1 --rm -v /var/run/docker.sock:/var/run/docker.sock spotify/docker-gc || true
 
 ## Run job on kubernetes after obtaining an exclusive lock
 circle\:run-job-kubernetes:


### PR DESCRIPTION
### What
Use smarter garbage collection for circle:cleanup-docker

### Why
https://github.com/spotify/docker-gc with the following settings:

remove images if they are tagged in multiple repositories
FORCE_IMAGE_REMOVAL=1

leave images that exited in the last 24 hours (debugging/cache re-use)
GRACE_PERIOD_SECONDS=86400

always keep the recent image for any repository (important for less frequently built)
MINIMUM_IMAGES_TO_SAVE=1

### Who
@darend @osterman @stevemcquaid 