### PR TITLE
Install deployment dependencies when circle:deps is executed

### DIFF
--- a/modules/Makefile.circleci-2.0
+++ b/modules/Makefile.circleci-2.0
@@ -21,7 +21,7 @@ export RELEASE
 .PHONY : circle\:tag circle\:release circle\:deps
 
 ## Install CircleCI deps
-circle\:deps: install-deployment-dependencies
+circle\:deps: install-deployment-dependencies build-compatible-go-binaries
 	@echo "Configuring for Circle ${CIRCLE_VERSION}"
 	@cat $(MAKEFILE_DIR)/retry.sh >> ~/.bashrc
 
@@ -88,3 +88,7 @@ ifdef APT_GET_EXISTS
 	@echo "Installing deployment dependencies"
 	@sudo apt-get install -y --no-install-recommends gettext
 endif
+
+# Ensure linux binaries are compatible
+build-compatible-go-binaries:
+	@echo 'export CGO_ENABLED=0' >> $BASH_ENV

--- a/modules/Makefile.circleci-2.0
+++ b/modules/Makefile.circleci-2.0
@@ -12,9 +12,6 @@ COMMIT ?= $(CIRCLE_SHA1)
 RELEASE ?= release-$(TIMESTAMP)
 DOCKER_BUILD_OPTS += --build-arg build=$(BUILD) --build-arg commit=$(COMMIT)
 
-# Look for apt-get
-APT_GET_EXISTS := $(shell command -v apt-get 2> /dev/null)
-
 export COMMIT
 export RELEASE
 
@@ -84,10 +81,7 @@ circle\:run-job-kubernetes:
 
 ## Install deployment dependencies
 install-deployment-dependencies:
-ifdef APT_GET_EXISTS
-	@echo "Installing deployment dependencies"
-	@sudo apt-get install -y --no-install-recommends gettext
-endif
+	@(! which -s apt-get || which -s gettext) || (echo "Installing deployment dependencies" && sudo apt-get install -y --no-install-recommends gettext)
 
 # Ensure linux binaries are compatible
 build-compatible-go-binaries:

--- a/modules/Makefile.circleci-2.0
+++ b/modules/Makefile.circleci-2.0
@@ -12,13 +12,16 @@ COMMIT ?= $(CIRCLE_SHA1)
 RELEASE ?= release-$(TIMESTAMP)
 DOCKER_BUILD_OPTS += --build-arg build=$(BUILD) --build-arg commit=$(COMMIT)
 
+# Look for apt-get
+APT_GET_EXISTS := $(shell command -v apt-get 2> /dev/null)
+
 export COMMIT
 export RELEASE
 
 .PHONY : circle\:tag circle\:release circle\:deps
 
 ## Install CircleCI deps
-circle\:deps:
+circle\:deps: install-deployment-dependencies
 	@echo "Configuring for Circle ${CIRCLE_VERSION}"
 	@cat $(MAKEFILE_DIR)/retry.sh >> ~/.bashrc
 
@@ -64,7 +67,7 @@ circle\:cleanup-docker:
 	@echo "INFO: Running Docker garbage collection"
 	@docker run -e FORCE_IMAGE_REMOVAL=1 -e GRACE_PERIOD_SECONDS=86400 -e MINIMUM_IMAGES_TO_SAVE=1 --rm -v /var/run/docker.sock:/var/run/docker.sock spotify/docker-gc || true
 	@echo "INFO: Docker disk usage after cleanup"
-	@docker system df -v 
+	@docker system df -v
 
 ## Run job on kubernetes after obtaining an exclusive lock
 circle\:run-job-kubernetes:
@@ -78,3 +81,10 @@ circle\:run-job-kubernetes:
 	  echo "INFO: Running $(JOB_KUBERNETES_APP):$(IMAGE_TAG)"; \
 	  $(MAKEFILE_DIR)/bin/circle-do-exclusively.sh --branch $(CIRCLE_BRANCH) $(SELF) kubernetes:run-job kubernetes:job-logs KUBERNETES_APP=$(JOB_KUBERNETES_APP); \
 	fi
+
+## Install deployment dependencies
+install-deployment-dependencies:
+ifdef APT_GET_EXISTS
+	@echo "Installing deployment dependencies"
+	@sudo apt-get install -y --no-install-recommends gettext
+endif


### PR DESCRIPTION
### What
Install deployment dependencies when circle:deps is executed

### Why
So that we don't have to remember to _always_ do it
https://github.com/sagansystems/remail/pull/4/files

### Who
@darend 