### PR TITLE
Fix `make docker:login` in circle by removing old support

### DIFF
--- a/modules/Makefile.docker
+++ b/modules/Makefile.docker
@@ -138,14 +138,8 @@ docker\:login:
 	@$(SELF) deps
 	@$(call assert_set,DOCKER_USER)
 	@$(call assert_set,DOCKER_PASS)
-	$(eval docker_version = $(shell docker version|grep Version | tail -n 1 | tr -s ' ' | cut -d ' ' -f3 | cut -d '.' -f 1 | cut -d . -f1))
-	@if [ ${docker_version} -gt 12 ]; then \
-		echo "INFO: Logging in as $(DOCKER_USER)"; \
-		$(DOCKER_CMD) login -u $(DOCKER_USER) -p $(DOCKER_PASS); \
-	else \
-		echo "INFO: Logging in as $(DOCKER_USER)/${DOCKER_EMAIL}"; \
-		$(DOCKER_CMD) login -e $(DOCKER_EMAIL) -u $(DOCKER_USER) -p $(DOCKER_PASS); \
-	fi
+	@echo "INFO: Logging in as $(DOCKER_USER)"
+	@$(DOCKER_CMD) login -u $(DOCKER_USER) -p $(DOCKER_PASS)
 
 ## Export docker images to file
 docker\:export:

--- a/modules/Makefile.docker
+++ b/modules/Makefile.docker
@@ -139,7 +139,7 @@ docker\:login:
 	@$(call assert_set,DOCKER_USER)
 	@$(call assert_set,DOCKER_PASS)
 	@echo "INFO: Logging in as $(DOCKER_USER)"
-	@$(DOCKER_CMD) login -u $(DOCKER_USER) -p $(DOCKER_PASS)
+	@$(DOCKER_CMD) login -e $(DOCKER_EMAIL) -u $(DOCKER_USER) -p $(DOCKER_PASS) || $(DOCKER_CMD) login -u $(DOCKER_USER) -p $(DOCKER_PASS)
 
 ## Export docker images to file
 docker\:export:


### PR DESCRIPTION
**Why**
Circle builds are failing to login to docker because our incantation to get the version doesn't work anymore.
https://circleci.com/gh/sagansystems/supernova/22014

It's doubtful that we need to support old docker versions 12 and below so simply removing conditional code.

**Testing**
- Try `make docker:login` locally and verify it work
- Verify CircleCI is using docker 17+ (it is)
- After commit verify a build of supernova (and other services) passes

<img width="898" alt="screen shot 2017-12-28 at 9 26 35 am" src="https://user-images.githubusercontent.com/4814876/34418424-ec42fc4c-ebb2-11e7-8399-a86341f4e946.png">
