### PR TITLE
Remove tagging of master as master-docker-latest

### DIFF
--- a/modules/Makefile.circleci-2.0
+++ b/modules/Makefile.circleci-2.0
@@ -34,8 +34,6 @@ circle\:tag-latest:
 	@echo "INFO: Tagging latest"
 	@$(SELF) DOCKER_TAG=latest docker:push
 	@git fetch --tags
-	@git tag --force "$(CIRCLE_BRANCH)-docker-latest"
-	@git push origin --force "tags/$(CIRCLE_BRANCH)-docker-latest"
 
 ## Tag and push official release to registry (CircleCI)
 circle\:release:


### PR DESCRIPTION
## what

Do not tag branches as `$branch-docker-latest` in `circle:tag-latest`

## why

This target is only used on `master` branches and the tag has never been used. The new tag also triggers a subsequent build 
