### PR TITLE
Deploy Gladly services to master - for migrating to Codefresh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.7
 
-ARG KUBE_VERSION="v1.8.7"
+ARG KUBE_VERSION="v1.8.10"
 
 RUN apk add --no-cache --update bash && \
     apk add ca-certificates && update-ca-certificates && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,8 @@ RUN apk add --no-cache --update bash && \
 RUN mkdir -p ~/.ssh/ && echo -e "Host github.com\n\tStrictHostKeyChecking no\n" > ~/.ssh/config
 
 ENV BUILD_HARNESS_PATH /gladly/build-harness
+ENV KUBECTL_CMD /usr/local/bin/kubectl
+ENV KUBECTL /usr/local/bin/kubectl
 
 WORKDIR /gladly/build-harness
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN apk add --no-cache --update bash && \
 RUN mkdir -p ~/.ssh/ && echo -e "Host github.com\n\tStrictHostKeyChecking no\n" > ~/.ssh/config
 
 ENV BUILD_HARNESS_PATH /gladly/build-harness
+ENV DOCKER_CMD /usr/bin/docker
 
 WORKDIR /gladly/build-harness
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,6 @@ RUN apk add --no-cache --update bash && \
 RUN mkdir -p ~/.ssh/ && echo -e "Host github.com\n\tStrictHostKeyChecking no\n" > ~/.ssh/config
 
 ENV BUILD_HARNESS_PATH /gladly/build-harness
-ENV DOCKER_CMD /usr/bin/docker
 
 WORKDIR /gladly/build-harness
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM alpine:3.7
+
+RUN apk add --no-cache --update bash && \
+    apk add make && \
+    apk add git
+
+WORKDIR /gladly/build-harness
+
+COPY . .
+
+ENTRYPOINT ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,9 @@ RUN apk add --no-cache --update bash && \
     apk add ca-certificates && update-ca-certificates && \
     apk add openssh && \
     apk add make && \
+    apk add gettext && \
     apk add docker && \
+    apk add which && \
     apk add curl && \
     curl -L https://storage.googleapis.com/kubernetes-release/release/${KUBE_VERSION}/bin/linux/amd64/kubectl -o /usr/local/bin/kubectl && \
     chmod +x /usr/local/bin/kubectl && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,25 @@
 FROM alpine:3.7
 
+ARG KUBE_VERSION="v1.8.7"
+
 RUN apk add --no-cache --update bash && \
+    apk add ca-certificates && update-ca-certificates && \
+    apk add openssh && \
     apk add make && \
-    apk add git
+    apk add docker && \
+    apk add curl && \
+    curl -L https://storage.googleapis.com/kubernetes-release/release/${KUBE_VERSION}/bin/linux/amd64/kubectl -o /usr/local/bin/kubectl && \
+    chmod +x /usr/local/bin/kubectl && \
+    apk add git && \
+    # Cleanup uncessary files
+    rm /var/cache/apk/* && \
+    rm -rf /tmp/*
+
+
+# Avoid unknown host for github
+RUN mkdir -p ~/.ssh/ && echo -e "Host github.com\n\tStrictHostKeyChecking no\n" > ~/.ssh/config
+
+ENV BUILD_HARNESS_PATH /gladly/build-harness
 
 WORKDIR /gladly/build-harness
 

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,10 @@ ifeq ($(CIRCLECI),true)
   endif
 endif
 
+ifdef CF_BUILD_ID # Codefresh
+  include $(MAKEFILE_DIR)/modules/Makefile.codefresh-1.0
+endif
+
 # Include the docker-specific targets
 include $(MAKEFILE_DIR)/modules/Makefile.docker
 

--- a/Makefile.shim
+++ b/Makefile.shim
@@ -1,7 +1,7 @@
 # This `Makefile` is intended to be included into other projects for the purpose of adding `Docker` capabilities
 PACKAGE_NAME = $(shell basename `pwd`)
 BUILD_HARNESS_MAKEFILE ?= $(BUILD_HARNESS_PATH)/Makefile
-BUILD_NAMESPACES=docker\:% circle\:% kubernetes\:% datadog\:%
+BUILD_NAMESPACES=docker\:% circle\:% kubernetes\:% datadog\:% codefresh\:%
 MAKEFILE_LIST += $(BUILD_HARNESS_MAKEFILE)
 
 include $(BUILD_HARNESS_PATH)/modules/Makefile.help

--- a/README.md
+++ b/README.md
@@ -170,8 +170,6 @@ Here's a minimal example of what is needed for CircleCI. Add/merge the following
       - CLUSTER_NAMESPACE=master
       - CLUSTER_DOMAIN=gladly.qa
       - IMAGE_TAG=${{CF_BRANCH_TAG_NORMALIZED}}-${{CF_SHORT_REVISION}}
-      - KUBECTL=/usr/local/bin/kubectl
-      - KUBECTL_CMD=/usr/local/bin/kubectl
     commands:
       - make codefresh:tag-deploy-cluster
     when:

--- a/README.md
+++ b/README.md
@@ -41,6 +41,14 @@ Run `make help` to get a list of available build targets
   circle:tag                Tag and push to registry (CircleCI)
   circle:release            Tag and push official release to registry (CircleCI)
   circle:cleanup-docker     Cleanup Docker images from CircleCI Docker cache. Calling it once in workflow (for example in the "build" job) should be enough.
+
+# Targets Available on Codefresh
+
+  codefresh:deps                      Install Codefresh deps
+  codefresh:git-tag-docker-latest     Tag as [branch]-docker-latest in git
+  codefresh:tag                       Tag using BUILD version and push to registry
+  codefresh:deploy-kubernetes         Deploy to kubernetes
+  codefresh:tag-deploy-cluster        Tag image as [branch]-docker-latest and deploy to the cluster
 ```
 
 ## Setting up your development environment
@@ -158,9 +166,9 @@ workflows:
 
 ## Codefresh Integration
 
-CircleCI will use the `codefresh` tag of build-harness. Once your build-harness change is merged into master, please advance the `codefresh` tag. You can also temporarily tag your branch with this tag to test your changes.
+Codefresh will use the `codefresh` tag of build-harness. Once your build-harness change is merged into master, please advance the `codefresh` tag. You can also temporarily tag your branch with this tag to test your changes.
 
-Here's a minimal example of what is needed for CircleCI. Add/merge the following to your projects `codefresh.yml` file.
+Here's a minimal example of what is needed for Codefresh. Add/merge the following to your projects `codefresh.yml` file.
 ```yaml
   deploy_master:
     title: Deploy to master

--- a/codefresh.yml
+++ b/codefresh.yml
@@ -1,0 +1,27 @@
+version: '1.0'
+steps:
+  build:
+    type: build
+    title: Build Docker Image
+    dockerfile: Dockerfile
+    image_name: sagan/${{CF_REPO_NAME}}
+
+  tag_branch:
+    type: push
+    title: Push docker image as branch
+    candidate: ${{build}}
+    registry: dockerhub
+    tags:
+      - ${{CF_BRANCH_TAG_NORMALIZED}}
+
+  tag_latest:
+    type: push
+    title: Tag master as latest
+    candidate: ${{build}}
+    tags:
+      - latest
+    registry: dockerhub
+    when:
+      branch:
+        only:
+          - master

--- a/modules/Makefile.circleci-1.0
+++ b/modules/Makefile.circleci-1.0
@@ -9,6 +9,9 @@ else
 BUILD ?= $(subst /,-,$(CIRCLE_BRANCH))-$(CIRCLE_BUILD_NUM)
 endif
 
+export CI_BUILD_NUM ?= $(CIRCLE_BUILD_NUM)
+export CI_BRANCH ?= $(CIRCLE_BRANCH)
+
 # Calculate timestamp exactly once at first evaluation
 TIMESTAMP := $(shell date -u +'%Y%m%d%H%M%SZ')
 COMMIT ?= $(CIRCLE_SHA1)

--- a/modules/Makefile.circleci-2.0
+++ b/modules/Makefile.circleci-2.0
@@ -6,6 +6,9 @@ else
 BUILD ?= $(subst /,-,$(CIRCLE_BRANCH))-$(CIRCLE_BUILD_NUM)
 endif
 
+export CI_BUILD_NUM ?= $(CIRCLE_BUILD_NUM)
+export CI_BRANCH ?= $(CIRCLE_BRANCH)
+
 # Calculate timestamp exactly once at first evaluation
 TIMESTAMP := $(shell date -u +'%Y%m%d%H%M%SZ')
 COMMIT ?= $(CIRCLE_SHA1)

--- a/modules/Makefile.codefresh-1.0
+++ b/modules/Makefile.codefresh-1.0
@@ -8,8 +8,14 @@ KUBECTL_NAMESPACE ?= sagan
 CODEFRESH_KUBERNETES_CONTEXT ?= $(CLUSTER_NAMESPACE)-$(subst .,-,$(CLUSTER_DOMAIN))
 DOCKER_BUILD_OPTS += --build-arg build=$(BUILD) --build-arg commit=$(COMMIT)
 
+# Calculate timestamp exactly once at first evaluation
+TIMESTAMP := $(shell date -u +'%Y%m%d%H%M%SZ')
+RELEASE ?= release-$(TIMESTAMP)
+
 export CI_BUILD_NUM ?= $(CF_BUILD_ID)
 export CI_BRANCH ?= $(CF_BRANCH_TAG_NORMALIZED)
+export COMMIT
+export RELEASE
 
 ## Install Codefresh deps
 codefresh\:deps:

--- a/modules/Makefile.codefresh-1.0
+++ b/modules/Makefile.codefresh-1.0
@@ -7,8 +7,9 @@ BUILD ?= $(CF_BRANCH_TAG_NORMALIZED)-$(CF_SHORT_REVISION)
 KUBECTL_NAMESPACE ?= sagan
 CODEFRESH_KUBERNETES_CONTEXT ?= $(CLUSTER_NAMESPACE)-$(subst .,-,$(CLUSTER_DOMAIN))
 DOCKER_BUILD_OPTS += --build-arg build=$(BUILD) --build-arg commit=$(COMMIT)
-export CIRCLE_BUILD_NUM ?= $(CF_BUILD_ID) # no concept of build number on Codefresh, faking for now
-export CIRCLE_BRANCH ?= $(CF_BRANCH_TAG_NORMALIZED)
+
+export CI_BUILD_NUM ?= $(CF_BUILD_ID)
+export CI_BRANCH ?= $(CF_BRANCH_TAG_NORMALIZED)
 
 ## Install Codefresh deps
 codefresh\:deps:

--- a/modules/Makefile.codefresh-1.0
+++ b/modules/Makefile.codefresh-1.0
@@ -41,7 +41,7 @@ codefresh\:deploy-kubernetes:
 	@$(SELF) kubernetes:list-deployments kubernetes:list-rs kubernetes:list-pods
 
 ## Tag image as [branch]-docker-latest and deploy to the cluster
-codefresh\:tag-deploy-cluster: deps
+codefresh\:tag-deploy-cluster: codefresh\:deps
 	@kubectl config set-context $(CODEFRESH_KUBERNETES_CONTEXT) --namespace=$(KUBECTL_NAMESPACE)
 	@kubectl config use-context $(CODEFRESH_KUBERNETES_CONTEXT)
 	@$(SELF) codefresh:git-tag-docker-latest

--- a/modules/Makefile.codefresh-1.0
+++ b/modules/Makefile.codefresh-1.0
@@ -7,6 +7,7 @@ BUILD ?= $(CF_BRANCH_TAG_NORMALIZED)-$(CF_SHORT_REVISION)
 KUBECTL_NAMESPACE ?= sagan
 CODEFRESH_KUBERNETES_CONTEXT ?= $(CLUSTER_NAMESPACE)-$(subst .,-,$(CLUSTER_DOMAIN))
 DOCKER_BUILD_OPTS += --build-arg build=$(BUILD) --build-arg commit=$(COMMIT)
+CIRCLE_BUILD_NUM ?= $(CF_BUILD_ID) # no concept of build number on Codefresh, faking for now
 
 ## Install Codefresh deps
 codefresh\:deps:

--- a/modules/Makefile.codefresh-1.0
+++ b/modules/Makefile.codefresh-1.0
@@ -11,7 +11,7 @@ CODEFRESH_KUBERNETES_CONTEXT ?= $(CLUSTER_NAMESPACE)-$(subst .,-,$(CLUSTER_DOMAI
 codefresh\:deps:
 	@echo "Configuring for Codefresh ${CODEFRESH_VERSION}"
 	@echo "INFO: Installing GitHub SSH key"
-	@echo -e $SSH_KEY > ~/.ssh/id_rsa
+	@echo -e $(SSH_KEY) > ~/.ssh/id_rsa
 	@chmod 600 ~/.ssh/id_rsa
 	@echo "INFO: Configuring github for ssh access"
 	@echo -e "[url \"ssh://git@github.com:\"]\\n\\tinsteadOf = https://github.com" >> ~/.gitconfig

--- a/modules/Makefile.codefresh-1.0
+++ b/modules/Makefile.codefresh-1.0
@@ -7,7 +7,8 @@ BUILD ?= $(CF_BRANCH_TAG_NORMALIZED)-$(CF_SHORT_REVISION)
 KUBECTL_NAMESPACE ?= sagan
 CODEFRESH_KUBERNETES_CONTEXT ?= $(CLUSTER_NAMESPACE)-$(subst .,-,$(CLUSTER_DOMAIN))
 DOCKER_BUILD_OPTS += --build-arg build=$(BUILD) --build-arg commit=$(COMMIT)
-CIRCLE_BUILD_NUM ?= $(CF_BUILD_ID) # no concept of build number on Codefresh, faking for now
+export CIRCLE_BUILD_NUM ?= $(CF_BUILD_ID) # no concept of build number on Codefresh, faking for now
+export CIRCLE_BRANCH ?= $(CF_BRANCH_TAG_NORMALIZED)
 
 ## Install Codefresh deps
 codefresh\:deps:

--- a/modules/Makefile.codefresh-1.0
+++ b/modules/Makefile.codefresh-1.0
@@ -35,13 +35,14 @@ codefresh\:tag:
 	@$(SELF) DOCKER_TAG=$(COMMIT) docker:tag docker:push
 
 
-## Deploy to kubernetes after obtaining an exclusive lock
+## Deploy to kubernetes
 codefresh\:deploy-kubernetes:
 	$(call assert,IMAGE_TAG)
 	$(call assert,CF_BRANCH_TAG_NORMALIZED)
+	$(call assert,COMMIT)
 	## @[ ! -f "$(DOCKER_FILE)" ] || $(SELF) codefresh:tag
 	@$(SELF) kubernetes:info
-	@echo -e "$(call red,WARN:) Deploying $(IMAGE_TAG) without obtaining lock"
+	@echo -e "INFO: Deploying $(IMAGE_TAG)"
 	@$(SELF) kubernetes:configure kubernetes:deploy KUBERNETES_ANNOTATION="$(RELEASE): $(BUILD) - commit $(COMMIT)"
 	@sleep 3
 	@$(SELF) kubernetes:list-deployments kubernetes:list-rs kubernetes:list-pods

--- a/modules/Makefile.codefresh-1.0
+++ b/modules/Makefile.codefresh-1.0
@@ -13,6 +13,8 @@ codefresh\:deps:
 	@echo "INFO: Installing GitHub SSH key"
 	@echo -e $SSH_KEY > ~/.ssh/id_rsa
 	@chmod 600 ~/.ssh/id_rsa
+	@echo "INFO: Configuring github for ssh access"
+	@echo -e "[url \"ssh://git@github.com:\"]\\n\\tinsteadOf = https://github.com" >> ~/.gitconfig
 
 ## Tag as [branch]-docker-latest in git
 codefresh\:git-tag-docker-latest:

--- a/modules/Makefile.codefresh-1.0
+++ b/modules/Makefile.codefresh-1.0
@@ -1,0 +1,40 @@
+export CODEFRESH_VERSION = "1.0"
+
+.PHONY : codefresh\:git-tag-docker-latest codefresh\:deploy-kubernetes codefresh\:tag-deploy-master
+
+COMMIT ?= $(CF_REVISION)
+BUILD ?= $(CF_BRANCH_TAG_NORMALIZED)-$(CF_SHORT_REVISION)
+KUBECTL_NAMESPACE ?= sagan
+
+## Tag as master-docker-latest in git
+codefresh\:git-tag-docker-latest:
+	@echo "INFO: Tagging git branch docker-latest"
+	@git fetch --tags
+	@git tag --force "$(CF_BRANCH_TAG_NORMALIZED)-docker-latest"
+	@git push origin --force "tags/$(CF_BRANCH_TAG_NORMALIZED)-docker-latest"
+
+## Tag using BUILD version and push to registry
+codefresh\:tag:
+	@$(call assert_set,BUILD)
+	@echo "INFO: Tagging $(COMMIT) as $(BUILD)"
+	@$(SELF) DOCKER_TAG=$(BUILD) docker:tag docker:push
+	@$(SELF) DOCKER_TAG=$(COMMIT) docker:tag docker:push
+
+
+## Deploy to kubernetes after obtaining an exclusive lock
+codefresh\:deploy-kubernetes:
+	$(call assert,IMAGE_TAG)
+	$(call assert,CF_BRANCH_TAG_NORMALIZED)
+	@[ ! -f "$(DOCKER_FILE)" ] || $(SELF) codefresh:tag
+	@$(SELF) kubernetes:info
+	@echo -e "$(call red,WARN:) Deploying $(IMAGE_TAG) without obtaining lock"
+	@$(SELF) kubernetes:configure kubernetes:deploy KUBERNETES_ANNOTATION="$(RELEASE): $(BUILD) - commit $(COMMIT)"; \
+	@sleep 3
+	@$(SELF) kubernetes:list-deployments kubernetes:list-rs kubernetes:list-pods
+
+## Tag image as master-docker-latest and deploy to master cluster
+codefresh\:tag-deploy-master:
+	@kubectl config set-context master-gladly-qa --namespace=$(KUBECTL_NAMESPACE)
+	@kubectl config use-context master-gladly-qa
+	@$(SELF) codefresh:git-tag-docker-latest
+	@$(SELF) codefresh:deploy-kubernetes

--- a/modules/Makefile.codefresh-1.0
+++ b/modules/Makefile.codefresh-1.0
@@ -1,12 +1,13 @@
 export CODEFRESH_VERSION = "1.0"
 
-.PHONY : codefresh\:git-tag-docker-latest codefresh\:deploy-kubernetes codefresh\:tag-deploy-master
+.PHONY : codefresh\:git-tag-docker-latest codefresh\:deploy-kubernetes codefresh\:tag-deploy-cluster
 
 COMMIT ?= $(CF_REVISION)
 BUILD ?= $(CF_BRANCH_TAG_NORMALIZED)-$(CF_SHORT_REVISION)
 KUBECTL_NAMESPACE ?= sagan
+CODEFRESH_KUBERNETES_CONTEXT ?= $(CLUSTER_NAMESPACE)-$(subst .,-,$(CLUSTER_DOMAIN))
 
-## Tag as master-docker-latest in git
+## Tag as [branch]-docker-latest in git
 codefresh\:git-tag-docker-latest:
 	@echo "INFO: Tagging git branch docker-latest"
 	@git fetch --tags
@@ -32,9 +33,9 @@ codefresh\:deploy-kubernetes:
 	@sleep 3
 	@$(SELF) kubernetes:list-deployments kubernetes:list-rs kubernetes:list-pods
 
-## Tag image as master-docker-latest and deploy to master cluster
-codefresh\:tag-deploy-master:
-	@kubectl config set-context master-gladly-qa --namespace=$(KUBECTL_NAMESPACE)
-	@kubectl config use-context master-gladly-qa
+## Tag image as [branch]-docker-latest and deploy to the cluster
+codefresh\:tag-deploy-cluster:
+	@kubectl config set-context $(CODEFRESH_KUBERNETES_CONTEXT) --namespace=$(KUBECTL_NAMESPACE)
+	@kubectl config use-context $(CODEFRESH_KUBERNETES_CONTEXT)
 	@$(SELF) codefresh:git-tag-docker-latest
 	@$(SELF) codefresh:deploy-kubernetes

--- a/modules/Makefile.codefresh-1.0
+++ b/modules/Makefile.codefresh-1.0
@@ -6,6 +6,7 @@ COMMIT ?= $(CF_REVISION)
 BUILD ?= $(CF_BRANCH_TAG_NORMALIZED)-$(CF_SHORT_REVISION)
 KUBECTL_NAMESPACE ?= sagan
 CODEFRESH_KUBERNETES_CONTEXT ?= $(CLUSTER_NAMESPACE)-$(subst .,-,$(CLUSTER_DOMAIN))
+DOCKER_BUILD_OPTS += --build-arg build=$(BUILD) --build-arg commit=$(COMMIT)
 
 ## Install Codefresh deps
 codefresh\:deps:

--- a/modules/Makefile.codefresh-1.0
+++ b/modules/Makefile.codefresh-1.0
@@ -11,7 +11,7 @@ CODEFRESH_KUBERNETES_CONTEXT ?= $(CLUSTER_NAMESPACE)-$(subst .,-,$(CLUSTER_DOMAI
 codefresh\:deps:
 	@echo "Configuring for Codefresh ${CODEFRESH_VERSION}"
 	@echo "INFO: Installing GitHub SSH key"
-	@echo -e $(SSH_KEY) > ~/.ssh/id_rsa
+	@echo -e "$(SSH_KEY)" > ~/.ssh/id_rsa
 	@chmod 600 ~/.ssh/id_rsa
 	@echo "INFO: Configuring github for ssh access"
 	@echo -e "[url \"ssh://git@github.com:\"]\\n\\tinsteadOf = https://github.com" >> ~/.gitconfig

--- a/modules/Makefile.codefresh-1.0
+++ b/modules/Makefile.codefresh-1.0
@@ -41,7 +41,7 @@ codefresh\:deploy-kubernetes:
 	## @[ ! -f "$(DOCKER_FILE)" ] || $(SELF) codefresh:tag
 	@$(SELF) kubernetes:info
 	@echo -e "$(call red,WARN:) Deploying $(IMAGE_TAG) without obtaining lock"
-	@$(SELF) kubernetes:configure kubernetes:deploy KUBERNETES_ANNOTATION="$(RELEASE): $(BUILD) - commit $(COMMIT)"; \
+	@$(SELF) kubernetes:configure kubernetes:deploy KUBERNETES_ANNOTATION="$(RELEASE): $(BUILD) - commit $(COMMIT)"
 	@sleep 3
 	@$(SELF) kubernetes:list-deployments kubernetes:list-rs kubernetes:list-pods
 

--- a/modules/Makefile.codefresh-1.0
+++ b/modules/Makefile.codefresh-1.0
@@ -1,11 +1,18 @@
 export CODEFRESH_VERSION = "1.0"
 
-.PHONY : codefresh\:git-tag-docker-latest codefresh\:deploy-kubernetes codefresh\:tag-deploy-cluster
+.PHONY : codefresh\:deps codefresh\:git-tag-docker-latest codefresh\:deploy-kubernetes codefresh\:tag-deploy-cluster
 
 COMMIT ?= $(CF_REVISION)
 BUILD ?= $(CF_BRANCH_TAG_NORMALIZED)-$(CF_SHORT_REVISION)
 KUBECTL_NAMESPACE ?= sagan
 CODEFRESH_KUBERNETES_CONTEXT ?= $(CLUSTER_NAMESPACE)-$(subst .,-,$(CLUSTER_DOMAIN))
+
+## Install Codefresh deps
+codefresh\:deps:
+	@echo "Configuring for Codefresh ${CODEFRESH_VERSION}"
+	@echo "INFO: Installing GitHub SSH key"
+	@echo -e $SSH_KEY > ~/.ssh/id_rsa
+	@chmod 600 ~/.ssh/id_rsa
 
 ## Tag as [branch]-docker-latest in git
 codefresh\:git-tag-docker-latest:
@@ -34,7 +41,7 @@ codefresh\:deploy-kubernetes:
 	@$(SELF) kubernetes:list-deployments kubernetes:list-rs kubernetes:list-pods
 
 ## Tag image as [branch]-docker-latest and deploy to the cluster
-codefresh\:tag-deploy-cluster:
+codefresh\:tag-deploy-cluster: deps
 	@kubectl config set-context $(CODEFRESH_KUBERNETES_CONTEXT) --namespace=$(KUBECTL_NAMESPACE)
 	@kubectl config use-context $(CODEFRESH_KUBERNETES_CONTEXT)
 	@$(SELF) codefresh:git-tag-docker-latest

--- a/modules/Makefile.codefresh-1.0
+++ b/modules/Makefile.codefresh-1.0
@@ -19,7 +19,7 @@ codefresh\:deps:
 
 ## Tag as [branch]-docker-latest in git
 codefresh\:git-tag-docker-latest:
-	@echo "INFO: Tagging git branch docker-latest"
+	@echo "INFO: Tagging git $(COMMIT) as $(CF_BRANCH_TAG_NORMALIZED)-docker-latest"
 	@git fetch --tags
 	@git tag --force "$(CF_BRANCH_TAG_NORMALIZED)-docker-latest"
 	@git push origin --force "tags/$(CF_BRANCH_TAG_NORMALIZED)-docker-latest"
@@ -36,7 +36,7 @@ codefresh\:tag:
 codefresh\:deploy-kubernetes:
 	$(call assert,IMAGE_TAG)
 	$(call assert,CF_BRANCH_TAG_NORMALIZED)
-	@[ ! -f "$(DOCKER_FILE)" ] || $(SELF) codefresh:tag
+	## @[ ! -f "$(DOCKER_FILE)" ] || $(SELF) codefresh:tag
 	@$(SELF) kubernetes:info
 	@echo -e "$(call red,WARN:) Deploying $(IMAGE_TAG) without obtaining lock"
 	@$(SELF) kubernetes:configure kubernetes:deploy KUBERNETES_ANNOTATION="$(RELEASE): $(BUILD) - commit $(COMMIT)"; \

--- a/modules/Makefile.docker
+++ b/modules/Makefile.docker
@@ -55,7 +55,7 @@ DOCKER_BUILD_OPTS ?=
 .PHONY : docker\:build docker\:push docker\:pull docker\:clean docker\:run docker\:shell docker\:attach docker\:update docker\:start docker\:stop docker\:rm docker\:logs
 
 deps::
-	$(call assert_set DOCKER_CMD)
+	$(call assert_set,DOCKER_CMD)
 	@[ -x $(DOCKER_CMD) ] || (echo "$(DOCKER_CMD) not executable"; exit 1)
 
 ## Display info about the docker environment

--- a/modules/datadog/Makefile
+++ b/modules/datadog/Makefile
@@ -15,8 +15,8 @@ define datadog_notify_deploy
 	$(call assert,DATADOG_API_KEY)
 	$(call assert,CLUSTER_NAMESPACE)
 	$(call assert,IMAGE_TAG)
-	$(call assert,CIRCLE_BUILD_NUM)
-	$(call assert,CIRCLE_BRANCH)
+	$(call assert,CI_BUILD_NUM)
+	$(call assert,CI_BRANCH)
 	@envsubst < $(MAKEFILE_DIR)/modules/datadog/$(1).json | $(CURL)
 endef
 

--- a/modules/datadog/Makefile
+++ b/modules/datadog/Makefile
@@ -14,6 +14,7 @@ define datadog_notify_deploy
 	$(call assert,KUBERNETES_APP)
 	$(call assert,DATADOG_API_KEY)
 	$(call assert,CLUSTER_NAMESPACE)
+	$(call assert,CLUSTER_DOMAIN)
 	$(call assert,IMAGE_TAG)
 	$(call assert,CI_BUILD_NUM)
 	$(call assert,CI_BRANCH)
@@ -36,6 +37,7 @@ define datadog_notify_release
 	$(call assert,KUBERNETES_APP)
 	$(call assert,DATADOG_API_KEY)
 	$(call assert,CLUSTER_NAMESPACE)
+	$(call assert,CLUSTER_DOMAIN)
 	$(call assert,IMAGE_TAG)
 	@envsubst < $(MAKEFILE_DIR)/modules/datadog/$(1).json | $(CURL)
 endef
@@ -54,12 +56,12 @@ datadog\:notify-release-failure:
 
 ## Notify stdout of a release is starting
 datadog\:notify-stdout-starting:
-	@echo "INFO: Rollout of $(KUBERNETES_APP):$(IMAGE_TAG) to $(CLUSTER_NAMESPACE) starting."
+	@echo "INFO: Rollout of $(KUBERNETES_APP):$(IMAGE_TAG) to $(CLUSTER_NAMESPACE).$(CLUSTER_DOMAIN) starting."
 
 ## Notify stdout of a release was successful
 datadog\:notify-stdout-success:
-	@echo "INFO: Rollout of $(KUBERNETES_APP):$(IMAGE_TAG) to $(CLUSTER_NAMESPACE) successful."
+	@echo "INFO: Rollout of $(KUBERNETES_APP):$(IMAGE_TAG) to $(CLUSTER_NAMESPACE).$(CLUSTER_DOMAIN) successful."
 
 ## Notify stdout of a release failure
 datadog\:notify-stdout-failure:
-	@echo "INFO: Rollout of $(KUBERNETES_APP):$(IMAGE_TAG) to $(CLUSTER_NAMESPACE) failed."
+	@echo "INFO: Rollout of $(KUBERNETES_APP):$(IMAGE_TAG) to $(CLUSTER_NAMESPACE).$(CLUSTER_DOMAIN) failed."

--- a/modules/datadog/deploy-failure.json
+++ b/modules/datadog/deploy-failure.json
@@ -1,9 +1,9 @@
 {
-  "title": "Failed to deploy $KUBERNETES_APP-$CIRCLE_BUILD_NUM to $CLUSTER_NAMESPACE",
-  "text": "Failed to deploy $KUBERNETES_APP build $CIRCLE_BUILD_NUM from branch $CIRCLE_BRANCH to $CLUSTER_NAMESPACE",
+  "title": "Failed to deploy $KUBERNETES_APP-$CI_BUILD_NUM to $CLUSTER_NAMESPACE",
+  "text": "Failed to deploy $KUBERNETES_APP build $CI_BUILD_NUM from branch $CI_BRANCH to $CLUSTER_NAMESPACE",
   "priority": "normal",
-  "tags": ["namespace:$CLUSTER_NAMESPACE","app:$KUBERNETES_APP","image:$IMAGE_TAG","build_number:$CIRCLE_BUILD_NUM","branch:$CIRCLE_BRANCH"],
+  "tags": ["namespace:$CLUSTER_NAMESPACE","app:$KUBERNETES_APP","image:$IMAGE_TAG","build_number:$CI_BUILD_NUM","branch:$CI_BRANCH"],
   "alert_type": "error",
   "source_type_name": "circleci",
-  "aggregation_key": "$CLUSTER_NAMESPACE-$KUBERNETES_APP-$CIRCLE_BUILD_NUM"
+  "aggregation_key": "$CLUSTER_NAMESPACE-$KUBERNETES_APP-$CI_BUILD_NUM"
 }

--- a/modules/datadog/deploy-failure.json
+++ b/modules/datadog/deploy-failure.json
@@ -1,9 +1,9 @@
 {
-  "title": "Failed to deploy $KUBERNETES_APP-$CI_BUILD_NUM to $CLUSTER_NAMESPACE",
-  "text": "Failed to deploy $KUBERNETES_APP build $CI_BUILD_NUM from branch $CI_BRANCH to $CLUSTER_NAMESPACE",
+  "title": "Failed to deploy $KUBERNETES_APP-$CI_BUILD_NUM to $CLUSTER_NAMESPACE.$CLUSTER_DOMAIN",
+  "text": "Failed to deploy $KUBERNETES_APP build $CI_BUILD_NUM from branch $CI_BRANCH to $CLUSTER_NAMESPACE.$CLUSTER_DOMAIN",
   "priority": "normal",
-  "tags": ["namespace:$CLUSTER_NAMESPACE","app:$KUBERNETES_APP","image:$IMAGE_TAG","build_number:$CI_BUILD_NUM","branch:$CI_BRANCH"],
+  "tags": ["cluster:$CLUSTER_NAMESPACE.$CLUSTER_DOMAIN","app:$KUBERNETES_APP","image:$IMAGE_TAG","build_number:$CI_BUILD_NUM","branch:$CI_BRANCH","deployment"],
   "alert_type": "error",
   "source_type_name": "circleci",
-  "aggregation_key": "$CLUSTER_NAMESPACE-$KUBERNETES_APP-$CI_BUILD_NUM"
+  "aggregation_key": "$CLUSTER_NAMESPACE.$CLUSTER_DOMAIN-$KUBERNETES_APP-$CI_BUILD_NUM"
 }

--- a/modules/datadog/deploy-starting.json
+++ b/modules/datadog/deploy-starting.json
@@ -1,10 +1,10 @@
 {
-  "title": "Deploying $KUBERNETES_APP-$CI_BUILD_NUM to $CLUSTER_NAMESPACE",
-  "text": "Deploying $KUBERNETES_APP build $CI_BUILD_NUM from branch $CI_BRANCH to $CLUSTER_NAMESPACE",
+  "title": "Deploying $KUBERNETES_APP-$CI_BUILD_NUM to $CLUSTER_NAMESPACE.$CLUSTER_DOMAIN",
+  "text": "Deploying $KUBERNETES_APP build $CI_BUILD_NUM from branch $CI_BRANCH to $CLUSTER_NAMESPACE.$CLUSTER_DOMAIN",
   "priority": "normal",
-  "tags": ["namespace:$CLUSTER_NAMESPACE","app:$KUBERNETES_APP","image:$IMAGE_TAG","build_number:$CI_BUILD_NUM","branch:$CI_BRANCH"],
+  "tags": ["cluster:$CLUSTER_NAMESPACE.$CLUSTER_DOMAIN","app:$KUBERNETES_APP","image:$IMAGE_TAG","build_number:$CI_BUILD_NUM","branch:$CI_BRANCH","deployment"],
   "alert_type": "info",
   "source_type_name": "circleci",
-  "aggregation_key": "$CLUSTER_NAMESPACE-$KUBERNETES_APP-$CI_BUILD_NUM"
+  "aggregation_key": "$CLUSTER_NAMESPACE.$CLUSTER_DOMAIN-$KUBERNETES_APP-$CI_BUILD_NUM"
 }
 

--- a/modules/datadog/deploy-starting.json
+++ b/modules/datadog/deploy-starting.json
@@ -1,10 +1,10 @@
 {
-  "title": "Deploying $KUBERNETES_APP-$CIRCLE_BUILD_NUM to $CLUSTER_NAMESPACE",
-  "text": "Deploying $KUBERNETES_APP build $CIRCLE_BUILD_NUM from branch $CIRCLE_BRANCH to $CLUSTER_NAMESPACE",
+  "title": "Deploying $KUBERNETES_APP-$CI_BUILD_NUM to $CLUSTER_NAMESPACE",
+  "text": "Deploying $KUBERNETES_APP build $CI_BUILD_NUM from branch $CI_BRANCH to $CLUSTER_NAMESPACE",
   "priority": "normal",
-  "tags": ["namespace:$CLUSTER_NAMESPACE","app:$KUBERNETES_APP","image:$IMAGE_TAG","build_number:$CIRCLE_BUILD_NUM","branch:$CIRCLE_BRANCH"],
+  "tags": ["namespace:$CLUSTER_NAMESPACE","app:$KUBERNETES_APP","image:$IMAGE_TAG","build_number:$CI_BUILD_NUM","branch:$CI_BRANCH"],
   "alert_type": "info",
   "source_type_name": "circleci",
-  "aggregation_key": "$CLUSTER_NAMESPACE-$KUBERNETES_APP-$CIRCLE_BUILD_NUM"
+  "aggregation_key": "$CLUSTER_NAMESPACE-$KUBERNETES_APP-$CI_BUILD_NUM"
 }
 

--- a/modules/datadog/deploy-success.json
+++ b/modules/datadog/deploy-success.json
@@ -1,9 +1,9 @@
 {
-  "title": "Deployed $KUBERNETES_APP-$CIRCLE_BUILD_NUM to $CLUSTER_NAMESPACE",
-  "text": "Deployed $KUBERNETES_APP build $CIRCLE_BUILD_NUM from branch $CIRCLE_BRANCH to $CLUSTER_NAMESPACE",
+  "title": "Deployed $KUBERNETES_APP-$CI_BUILD_NUM to $CLUSTER_NAMESPACE",
+  "text": "Deployed $KUBERNETES_APP build $CI_BUILD_NUM from branch $CI_BRANCH to $CLUSTER_NAMESPACE",
   "priority": "normal",
-  "tags": ["namespace:$CLUSTER_NAMESPACE","app:$KUBERNETES_APP","image:$IMAGE_TAG","build_number:$CIRCLE_BUILD_NUM","branch:$CIRCLE_BRANCH"],
+  "tags": ["namespace:$CLUSTER_NAMESPACE","app:$KUBERNETES_APP","image:$IMAGE_TAG","build_number:$CI_BUILD_NUM","branch:$CI_BRANCH"],
   "alert_type": "success",
   "source_type_name": "circleci",
-  "aggregation_key": "$CLUSTER_NAMESPACE-$KUBERNETES_APP-$CIRCLE_BUILD_NUM"
+  "aggregation_key": "$CLUSTER_NAMESPACE-$KUBERNETES_APP-$CI_BUILD_NUM"
 }

--- a/modules/datadog/deploy-success.json
+++ b/modules/datadog/deploy-success.json
@@ -1,9 +1,9 @@
 {
-  "title": "Deployed $KUBERNETES_APP-$CI_BUILD_NUM to $CLUSTER_NAMESPACE",
-  "text": "Deployed $KUBERNETES_APP build $CI_BUILD_NUM from branch $CI_BRANCH to $CLUSTER_NAMESPACE",
+  "title": "Deployed $KUBERNETES_APP-$CI_BUILD_NUM to $CLUSTER_NAMESPACE.$CLUSTER_DOMAIN",
+  "text": "Deployed $KUBERNETES_APP build $CI_BUILD_NUM from branch $CI_BRANCH to $CLUSTER_NAMESPACE.$CLUSTER_DOMAIN",
   "priority": "normal",
-  "tags": ["namespace:$CLUSTER_NAMESPACE","app:$KUBERNETES_APP","image:$IMAGE_TAG","build_number:$CI_BUILD_NUM","branch:$CI_BRANCH"],
+  "tags": ["cluster:$CLUSTER_NAMESPACE.$CLUSTER_DOMAIN","app:$KUBERNETES_APP","image:$IMAGE_TAG","build_number:$CI_BUILD_NUM","branch:$CI_BRANCH","deployment"],
   "alert_type": "success",
   "source_type_name": "circleci",
-  "aggregation_key": "$CLUSTER_NAMESPACE-$KUBERNETES_APP-$CI_BUILD_NUM"
+  "aggregation_key": "$CLUSTER_NAMESPACE.$CLUSTER_DOMAIN-$KUBERNETES_APP-$CI_BUILD_NUM"
 }

--- a/modules/datadog/release-failure.json
+++ b/modules/datadog/release-failure.json
@@ -1,9 +1,9 @@
 {
-  "title": "Failed to release $KUBERNETES_APP:$IMAGE_TAG to $CLUSTER_NAMESPACE",
-  "text": "Failed to release $KUBERNETES_APP:$IMAGE_TAG to $CLUSTER_NAMESPACE",
+  "title": "Failed to release $KUBERNETES_APP:$IMAGE_TAG to $CLUSTER_NAMESPACE.$CLUSTER_DOMAIN",
+  "text": "Failed to release $KUBERNETES_APP:$IMAGE_TAG to $CLUSTER_NAMESPACE.$CLUSTER_DOMAIN",
   "priority": "normal",
-  "tags": ["namespace:$CLUSTER_NAMESPACE","app:$KUBERNETES_APP","image:$IMAGE_TAG"],
+  "tags": ["cluster:$CLUSTER_NAMESPACE.$CLUSTER_DOMAIN","app:$KUBERNETES_APP","image:$IMAGE_TAG","release"],
   "alert_type": "error",
   "source_type_name": "release",
-  "aggregation_key": "$CLUSTER_NAMESPACE-$KUBERNETES_APP-$IMAGE_TAG"
+  "aggregation_key": "$CLUSTER_NAMESPACE.$CLUSTER_DOMAIN-$KUBERNETES_APP-$IMAGE_TAG"
 }

--- a/modules/datadog/release-starting.json
+++ b/modules/datadog/release-starting.json
@@ -1,10 +1,10 @@
 {
-  "title": "Releasing $KUBERNETES_APP:$IMAGE_TAG to $CLUSTER_NAMESPACE",
-  "text": "Releasing $KUBERNETES_APP:$IMAGE_TAG to $CLUSTER_NAMESPACE",
+  "title": "Releasing $KUBERNETES_APP:$IMAGE_TAG to $CLUSTER_NAMESPACE.$CLUSTER_DOMAIN",
+  "text": "Releasing $KUBERNETES_APP:$IMAGE_TAG to $CLUSTER_NAMESPACE.$CLUSTER_DOMAIN",
   "priority": "normal",
-  "tags": ["namespace:$CLUSTER_NAMESPACE","app:$KUBERNETES_APP","image:$IMAGE_TAG"],
+  "tags": ["cluster:$CLUSTER_NAMESPACE.$CLUSTER_DOMAIN","app:$KUBERNETES_APP","image:$IMAGE_TAG","release"],
   "alert_type": "info",
   "source_type_name": "release",
-  "aggregation_key": "$CLUSTER_NAMESPACE-$KUBERNETES_APP-$IMAGE_TAG"
+  "aggregation_key": "$CLUSTER_NAMESPACE.$CLUSTER_DOMAIN-$KUBERNETES_APP-$IMAGE_TAG"
 }
 

--- a/modules/datadog/release-success.json
+++ b/modules/datadog/release-success.json
@@ -1,9 +1,9 @@
 {
-  "title": "Released $KUBERNETES_APP:$IMAGE_TAG to $CLUSTER_NAMESPACE",
-  "text": "Released $KUBERNETES_APP:$IMAGE_TAG to $CLUSTER_NAMESPACE",
+  "title": "Released $KUBERNETES_APP:$IMAGE_TAG to $CLUSTER_NAMESPACE.$CLUSTER_DOMAIN",
+  "text": "Released $KUBERNETES_APP:$IMAGE_TAG to $CLUSTER_NAMESPACE.$CLUSTER_DOMAIN",
   "priority": "normal",
-  "tags": ["namespace:$CLUSTER_NAMESPACE","app:$KUBERNETES_APP","image:$IMAGE_TAG"],
+  "tags": ["cluster:$CLUSTER_NAMESPACE.$CLUSTER_DOMAIN","app:$KUBERNETES_APP","image:$IMAGE_TAG","release"],
   "alert_type": "success",
   "source_type_name": "release",
-  "aggregation_key": "$CLUSTER_NAMESPACE-$KUBERNETES_APP-$IMAGE_TAG"
+  "aggregation_key": "$CLUSTER_NAMESPACE.$CLUSTER_DOMAIN-$KUBERNETES_APP-$IMAGE_TAG"
 }


### PR DESCRIPTION
build-harness additions to make deployment with Codefresh as simple as the `deploy_master` step in: https://github.com/sagansystems/synthetic/pull/149/files#diff-4b1f0ce1002ac596118dad4b3eea3f1c

Specific changes:
- build-harness now a dockerfile to drive Codefresh deploys, and that docker itself is built on Codefresh

- setting some build-harness environment variables inside docker itself, so that all upstream scripts can pick them up

- documentation changes for the `codefresh` tag

- Makefile.codefresh-1.0 has Codefresh-specific version of the steps

- Abstracted CIRCLE_BUILD_NUM for Datadog to be CI_BUILD_NUM to account for Codefresh or Circle

- One place fixed where `call assert_set` was breaking


Deployments of Gladly services to master with Codefresh would need:
1) Creating codefresh.yml file like Daren created in https://github.com/sagansystems/synthetic/pull/149
2) Copy/pasting ENV variables from Circle to Codefresh - one time simple effort: run Circle in SSH mode, extract, add to Codefresh as shared secrets
