### PR TITLE
Remove -configmap/-secrets deployment from build-harness

### DIFF
--- a/modules/Makefile.circleci-1.0
+++ b/modules/Makefile.circleci-1.0
@@ -71,10 +71,10 @@ circle\:deploy-kubernetes:
 	@$(SELF) kubernetes:info
 	@if [ -z "$(CIRCLE_TOKEN)" ]; then \
 	  echo -e "$(call red,WARN:) Deploying $(IMAGE_TAG) without obtaining lock; CIRCLE_TOKEN not defined"; \
-	  $(SELF) kubernetes:configure kubernetes:deploy KUBERNETES_ANNOTATION="$(RELEASE): $(BUILD) - commit $(COMMIT)"; \
+	  $(SELF) kubernetes:deploy KUBERNETES_ANNOTATION="$(RELEASE): $(BUILD) - commit $(COMMIT)"; \
   else \
 	  echo "INFO: Deploying $(IMAGE_TAG)"; \
-	  $(MAKEFILE_DIR)/bin/circle-do-exclusively.sh --branch $(CIRCLE_BRANCH) $(SELF) kubernetes:configure kubernetes:deploy; \
+	  $(MAKEFILE_DIR)/bin/circle-do-exclusively.sh --branch $(CIRCLE_BRANCH) $(SELF) kubernetes:deploy; \
   fi
 	@sleep 3
 	@$(SELF) kubernetes:list-deployments kubernetes:list-rs kubernetes:list-pods

--- a/modules/Makefile.circleci-2.0
+++ b/modules/Makefile.circleci-2.0
@@ -54,10 +54,10 @@ circle\:deploy-kubernetes:
 	@$(SELF) kubernetes:info
 	@if [ -z "$(CIRCLE_TOKEN)" ]; then \
 	  echo -e "$(call red,WARN:) Deploying $(IMAGE_TAG) without obtaining lock; CIRCLE_TOKEN not defined"; \
-	  $(SELF) kubernetes:configure kubernetes:deploy KUBERNETES_ANNOTATION="$(RELEASE): $(BUILD) - commit $(COMMIT)"; \
+	  $(SELF) kubernetes:deploy KUBERNETES_ANNOTATION="$(RELEASE): $(BUILD) - commit $(COMMIT)"; \
   else \
 	  echo "INFO: Deploying $(IMAGE_TAG)"; \
-	  $(MAKEFILE_DIR)/bin/circle-do-exclusively.sh --branch $(CIRCLE_BRANCH) $(SELF) kubernetes:configure kubernetes:deploy; \
+	  $(MAKEFILE_DIR)/bin/circle-do-exclusively.sh --branch $(CIRCLE_BRANCH) $(SELF) kubernetes:deploy; \
   fi
 	@sleep 3
 	@$(SELF) kubernetes:list-deployments kubernetes:list-rs kubernetes:list-pods

--- a/modules/Makefile.codefresh-1.0
+++ b/modules/Makefile.codefresh-1.0
@@ -49,7 +49,7 @@ codefresh\:deploy-kubernetes:
 	## @[ ! -f "$(DOCKER_FILE)" ] || $(SELF) codefresh:tag
 	@$(SELF) kubernetes:info
 	@echo -e "INFO: Deploying $(IMAGE_TAG)"
-	@$(SELF) kubernetes:configure kubernetes:deploy KUBERNETES_ANNOTATION="$(RELEASE): $(BUILD) - commit $(COMMIT)"
+	@$(SELF) kubernetes:deploy KUBERNETES_ANNOTATION="$(RELEASE): $(BUILD) - commit $(COMMIT)"
 	@sleep 3
 	@$(SELF) kubernetes:list-deployments kubernetes:list-rs kubernetes:list-pods
 

--- a/modules/Makefile.kubernetes
+++ b/modules/Makefile.kubernetes
@@ -121,27 +121,6 @@ kubernetes\:delete-horizontalpodautoscaler:
 kubernetes\:apply-horizontalpodautoscaler:
 	$(call kubectl_apply,horizontalpodautoscaler)
 
-# (private) Delete a configmap
-kubernetes\:delete-configmap:
-	$(call kubectl_delete,configmap)
-
-# (private) Update configmap or create, if necessary
-kubernetes\:apply-configmap:
-	$(call kubectl_apply,configmap)
-
-# (private) Delete a secrets
-kubernetes\:delete-secrets:
-	$(call kubectl_delete,secrets)
-
-# (private) Update secrets or create, if necessary
-kubernetes\:apply-secrets:
-	$(call kubectl_apply,secrets)
-
-## Update app configmaps and secrets
-kubernetes\:configure:
-	@[ ! -f "$(KUBERNETES_RESOURCE_PATH)/$(KUBERNETES_APP)-configmap.yml" ] || $(SELF) kubernetes:apply-configmap || $(NOTIFY_FAILURE)
-	@[ ! -f "$(KUBERNETES_RESOURCE_PATH)/$(KUBERNETES_APP)-secrets.yml" ] || $(SELF) kubernetes:apply-secrets || $(NOTIFY_FAILURE)
-	
 # (private) Delete a service
 kubernetes\:delete-service:
 	$(call kubectl_delete,service)


### PR DESCRIPTION
**Why**
We are moving to centrally-managed configmaps/secrets.

**Release Notes**
N/A

**Testing**
Services deploy from Circle/Codefresh to master

Clubhouse: https://app.clubhouse.io/gladly/story/11068/drop-config-secret-deployment-from-build-harness