### PR TITLE
Upgrade to alpine 3.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:3.8
 
 ARG KUBE_VERSION="v1.8.10"
 


### PR DESCRIPTION
## WHAT
Update alpine base image to get around pcre2 version pin in alpine 3.7

## WHY
PCI Complience

## TESTING
Not entirely sure.

## TWISTLOCK
<img width="928" alt="screen shot 2018-08-28 at 1 13 55 pm" src="https://user-images.githubusercontent.com/38445111/44748372-7bac4700-aac4-11e8-9bd6-3855e83e2fa6.png">
