### PR TITLE
[experimental - do not merge] Disable waiting for kubectl status for deployments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ ENV BUILD_HARNESS_PATH /gladly/build-harness
 ENV KUBECTL_CMD /usr/local/bin/kubectl
 ENV KUBECTL /usr/local/bin/kubectl
 ENV KUBEUTIL $BUILD_HARNESS_PATH/kube-util
+ENV KUBECTL_STATUS false
 WORKDIR $BUILD_HARNESS_PATH
 
 COPY . .


### PR DESCRIPTION
**Why**
Slow dockerhub downloads make it timeout

**Testing**
Deployments don't check status and move on


Will tag this branch as `codefresh` to see