### PR TITLE
make KUBECTL_SSH_CMD overridable

### DIFF
--- a/modules/Makefile.kubernetes
+++ b/modules/Makefile.kubernetes
@@ -58,7 +58,7 @@ SSH_PROXY_OPTIONS := -i ~/.tsh/keys/portal.$(CLUSTER)/$(OKTA_USER) -o ProxyComma
 # More kubectl specific settings
 KUBECTL_SSH_SOCK ?= /tmp/kubectl-$(CLUSTER_BASTION)
 KUBECTL_SSH_OPTS := -l $(KUBECTL_SSH_USER) -A -o 'LogLevel=error' -o 'StrictHostKeyChecking=no' -o 'UserKnownHostsFile=/dev/null' -S $(KUBECTL_SSH_SOCK)
-KUBECTL_SSH_CMD := ssh $(KUBECTL_SSH_OPTS)
+KUBECTL_SSH_CMD ?= ssh $(KUBECTL_SSH_OPTS)
 
 # Add the SSH endpoint to the command; everything after the host is expected to be a remote command
 KUBECTL_SSH_CMD += $(CLUSTER_BASTION)


### PR DESCRIPTION
##### WHAT

make KUBECTL_SSH_CMD overridable

##### WHY

need to be able to override it from here:

https://github.com/sagansystems/release-harness/blob/44bd61c86bf57f0417af73baf3c535533ecea580/bin/run-job.sh#L48

in order to use `release-harness` without an SSH tunnel for kubernetes (ie bastion)