### PR TITLE
Address security stuff reported by twistlock

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8
+FROM alpine:3.9
 
 ARG KUBE_VERSION="v1.10.11"
 


### PR DESCRIPTION
**Why**
Before:
```
Vulnerabilities
---------------
Image                                      ID                  CVE               Package    Version      Severity    Status
-----                                      --                  ---               -------    -------      --------    ------
docker.io/sagan/build-harness:codefresh    942375cc5796c717    CVE-2018-15919    openssh    7.7_p1-r3    medium      fixed in 7.9_p1-r2
docker.io/sagan/build-harness:codefresh    942375cc5796c717    CVE-2019-6109     openssh    7.7_p1-r3    medium      fixed in 7.9_p1-r2
docker.io/sagan/build-harness:codefresh    942375cc5796c717    CVE-2019-6110     openssh    7.7_p1-r3    medium      fixed in 7.9_p1-r2
```
After:
```
Vulnerabilities
---------------
Image    ID    CVE    Package    Version    Severity    Status
-----    --    ---    -------    -------    --------    ------
```


**Testing**
Twistlock does not complain.



btw. twistlock UI shows the below, not sure why given twistcli scan shows what I reported above:
![2019-02-14_1147](https://user-images.githubusercontent.com/2279299/52813338-66b17900-304e-11e9-8dcb-d1c8701e8b9c.png)
