### PR TITLE
Force force overwrite of local reference when fetching tags before tagging

### DIFF
--- a/modules/Makefile.codefresh-1.0
+++ b/modules/Makefile.codefresh-1.0
@@ -32,7 +32,7 @@ codefresh\:git-tag-docker-latest: codefresh\:deps
 	@$(call assert_set,COMMIT)
 	@$(call assert_set,CF_BRANCH_TAG_NORMALIZED)
 	@echo "INFO: Tagging git $(COMMIT) as $(CF_BRANCH_TAG_NORMALIZED)-docker-latest"
-	@git fetch --tags
+	@git fetch --tags --force
 	@git tag --force "$(CF_BRANCH_TAG_NORMALIZED)-docker-latest"
 	@git push origin --force "tags/$(CF_BRANCH_TAG_NORMALIZED)-docker-latest"
 


### PR DESCRIPTION
**Why**
Prevent `(would clobber existing tag)` like in:
https://g.codefresh.io/build/5c6f509d931ff2b805611b46?step=deploy_master&tab=output

Root cause - timing/race condition between builds. Codefresh does not
guarantee that builds will be deployed in commit order, and since we tag
with `master-docker-latest` on deploy we can hit an issue where one build
moves this tag as another one attempts to fetch tags.

`--force` will move the tag if it was moved by another build

(by the way: this problem to be at least partially solved as part of
CI/CD work where we will have separated build from deployment pipeline)

**Testing**
`(would clobber existing tag)` no longer happening, `master-docker-latest`
moved as expected