### PR TITLE
Force fetch/move local tags before advancing master-docker-latest

### DIFF
--- a/modules/Makefile.codefresh-1.0
+++ b/modules/Makefile.codefresh-1.0
@@ -32,8 +32,8 @@ codefresh\:git-tag-docker-latest: codefresh\:deps
 	@$(call assert_set,COMMIT)
 	@$(call assert_set,CF_BRANCH_TAG_NORMALIZED)
 	@echo "INFO: Tagging git $(COMMIT) as $(CF_BRANCH_TAG_NORMALIZED)-docker-latest"
+	@git fetch --tags --force
 	@git tag -d "$(CF_BRANCH_TAG_NORMALIZED)-docker-latest"
-	@git fetch --tags
 	@git tag --force "$(CF_BRANCH_TAG_NORMALIZED)-docker-latest"
 	@git push origin --force "tags/$(CF_BRANCH_TAG_NORMALIZED)-docker-latest"
 


### PR DESCRIPTION
**Why**
https://g.codefresh.io/build/5c82d9ad039a838c245710dc?step=deploy_master&tab=output
`git fetch --tags` rejected to advance local tag
this can sometimes happen per:
https://git-scm.com/docs/git-fetch#Documentation/git-fetch.txt-ltrefspecgt

`--force` should resolve it. Also I am moving it before I delete/move `master-docker-latest` so that we don't fetch upstream changes when we are about to move the tag.

**Testing**
No longer hitting rejected / would clobber existing tag