### PR TITLE
Allow for specifying k8s parameters per-cluster

### DIFF
--- a/modules/Makefile.kubernetes
+++ b/modules/Makefile.kubernetes
@@ -27,7 +27,13 @@ define kubectl_apply
 	$(call assert,CLUSTER_NAMESPACE)
 	$(call assert,CLUSTER_DOMAIN)
 	@echo -e "INFO: Applying changes to $(KUBERNETES_APP) $(1) on cluster $(call yellow,$(CLUSTER))..."
-	@$(call envsubst,$(KUBERNETES_RESOURCE_PATH)/$(KUBERNETES_APP)-$(1).yml) | $(KUBECTL_CMD) apply $(2) -f -
+	# Optionally load parameters for the kubernetes resources
+	@\
+	set -a; \
+	source $(KUBERNETES_RESOURCE_PATH)/config/default.k8sparameters || true; \
+	source $(KUBERNETES_RESOURCE_PATH)/config/$(CLUSTER_NAMESPACE).$(CLUSTER_DOMAIN).k8sparameters || true; \
+	set +a; \
+	$(call envsubst,$(KUBERNETES_RESOURCE_PATH)/$(KUBERNETES_APP)-$(1).yml) | $(KUBECTL_CMD) apply $(2) -f -
 endef
 
 define kubectl_create

--- a/modules/Makefile.kubernetes
+++ b/modules/Makefile.kubernetes
@@ -20,6 +20,11 @@ export SERIAL
 DEBUG ?= /dev/null
 
 define envsubst
+	# Optionally load parameters for the kubernetes resources
+	set -a; \
+	source $(KUBERNETES_RESOURCE_PATH)/config/default.k8sparameters || true; \
+	source $(KUBERNETES_RESOURCE_PATH)/config/$(CLUSTER_NAMESPACE).$(CLUSTER_DOMAIN).k8sparameters || true; \
+	set +a; \
 	envsubst < "$(1)" | envsubst | tee $(DEBUG)
 endef
 
@@ -27,13 +32,7 @@ define kubectl_apply
 	$(call assert,CLUSTER_NAMESPACE)
 	$(call assert,CLUSTER_DOMAIN)
 	@echo -e "INFO: Applying changes to $(KUBERNETES_APP) $(1) on cluster $(call yellow,$(CLUSTER))..."
-	# Optionally load parameters for the kubernetes resources
-	@\
-	set -a; \
-	source $(KUBERNETES_RESOURCE_PATH)/config/default.k8sparameters || true; \
-	source $(KUBERNETES_RESOURCE_PATH)/config/$(CLUSTER_NAMESPACE).$(CLUSTER_DOMAIN).k8sparameters || true; \
-	set +a; \
-	$(call envsubst,$(KUBERNETES_RESOURCE_PATH)/$(KUBERNETES_APP)-$(1).yml) | $(KUBECTL_CMD) apply $(2) -f -
+	@$(call envsubst,$(KUBERNETES_RESOURCE_PATH)/$(KUBERNETES_APP)-$(1).yml) | $(KUBECTL_CMD) apply $(2) -f -
 endef
 
 define kubectl_create


### PR DESCRIPTION
**Why**
https://www.notion.so/gladly/Update-resource-requirements-RAM-CPU-in-kubernetes-deployment-descriptors-for-supernova-and-edge-716d7be38f024525875ddb3e240f9134

**Testing**
Should work with https://github.com/sagansystems/edge-broker/pull/382

1) Provide both default and cluster-specific values: cluster-specific should win
2) Provide only default values: should get picked up
3) Provide neither: deployment fails (kubectl cannot apply invalid file)
