### PR TITLE
Bump kubectl and alpine versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM alpine:3.11
+FROM alpine:3.12
 
-ARG KUBE_VERSION="v1.12.10"
+ARG KUBE_VERSION="v1.16.10"
 
 RUN apk add --no-cache --update bash && \
     apk add ca-certificates && update-ca-certificates && \


### PR DESCRIPTION
**Why**
Our kubernetes clusters are on 1.15 already and on 1.16 soon.
kubectl 1.16 should be backwards compatible with 1.15 server.

Also bumping Alpine while I'm there.

**Testing**
will tag as build-harness:codefresh and run some jobs (like AD build etc)