### PR TITLE
Add KUBERNETES_JOB_NAME_SUFFIX so jobs of the same type can be named differently

### DIFF
--- a/modules/Makefile.codefresh-1.0
+++ b/modules/Makefile.codefresh-1.0
@@ -17,6 +17,8 @@ export CI_BRANCH ?= $(CF_BRANCH_TAG_NORMALIZED)
 export COMMIT
 export RELEASE
 
+export KUBERNETES_JOB_NAME_SUFFIX ?= $(JOB_KUBERNETES_NAME_SUFFIX)
+
 ## Install Codefresh deps
 codefresh\:deps:
 	@$(call assert_set,SSH_KEY)

--- a/modules/Makefile.codefresh-1.0
+++ b/modules/Makefile.codefresh-1.0
@@ -75,4 +75,4 @@ codefresh\:run-job-kubernetes:
 	$(call assert,JOB_KUBERNETES_APP)
 	@$(SELF) codefresh:set-context
 	@echo -e "INFO: Running $(JOB_KUBERNETES_APP):$(IMAGE_TAG) on $(CODEFRESH_KUBERNETES_CONTEXT)"
-	@$(SELF) kubernetes:run-job kubernetes:job-logs KUBERNETES_APP=$(JOB_KUBERNETES_APP)
+	@$(SELF) kubernetes:run-job kubernetes:job-logs KUBERNETES_APP=$(JOB_KUBERNETES_APP) KUBERNETES_JOB_NAME_SUFFIX=$(JOB_KUBERNETES_NAME_SUFFIX)

--- a/modules/Makefile.kubernetes
+++ b/modules/Makefile.kubernetes
@@ -45,7 +45,7 @@ endef
 define kubectl_delete
 	$(call assert,CLUSTER_NAMESPACE)
 	$(call assert,CLUSTER_DOMAIN)
-	@echo -e "INFO: Deleteting $(KUBERNETES_APP) $(1) on cluster $(call yellow,$(CLUSTER))..."
+	@echo -e "INFO: Deleting $(KUBERNETES_APP) $(1) on cluster $(call yellow,$(CLUSTER))..."
 	@$(call envsubst,$(KUBERNETES_RESOURCE_PATH)/$(KUBERNETES_APP)-$(1).yml) | $(KUBECTL_CMD) delete --ignore-not-found=true -f -
 endef
 
@@ -175,8 +175,8 @@ kubernetes\:run-job:
 
 ## Show job logs and return job exit code, requires SSH if ran outside Codefresh
 kubernetes\:job-logs:
-	@echo -e "INFO: Monitoring job $(KUBERNETES_APP) on cluster $(call yellow,$(CLUSTER))..."
-	$(KUBEUTIL) tail-job $(KUBERNETES_APP); \
+	@echo -e "INFO: Monitoring job $(KUBERNETES_APP)$(KUBERNETES_JOB_NAME_SUFFIX) on cluster $(call yellow,$(CLUSTER))..."
+	$(KUBEUTIL) tail-job $(KUBERNETES_APP)$(KUBERNETES_JOB_NAME_SUFFIX); \
 
 ## Output the status of the deployment
 kubernetes\:status:


### PR DESCRIPTION
## What
Add KUBERNETES_JOB_NAME_SUFFIX so jobs of the same type can be named differently.  For example, look at https://github.com/sagansystems/supernova/pull/10198.  The codefresh build id is added as a suffix so that multiple instances of the job can be run at once.

## Why
Without the change to `job-logs`, it looks like codefresh won't get the job status.  It runs correctly, but codefresh is unaware.  It looks like `validate-job` and `delete-job` are fine as-is since they use the yaml.

```
Waiting for job <JOB> to start...                                                                                                                           
No resources found in <NAMESPACE> namespace.                                                                                                                                               
Job Status:                                                                                                                                                                          
No resources found in <NAMESPACE> namespace.                                                                                                                                               
Job Status:
```
