### PR TITLE
Add coreutils to build-harness

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,20 +2,13 @@ FROM alpine:3.12
 
 ARG KUBE_VERSION="v1.16.10"
 
-RUN apk add --no-cache --update bash && \
-    apk add ca-certificates && update-ca-certificates && \
-    apk add openssh && \
-    apk add make && \
-    apk add gettext && \
-    apk add docker && \
-    apk add which && \
-    apk add curl && \
+RUN apk add --no-cache --update bash ca-certificates openssh make gettext \
+    docker which curl coreutils git && \
+    update-ca-certificates && \
     curl -L https://storage.googleapis.com/kubernetes-release/release/${KUBE_VERSION}/bin/linux/amd64/kubectl -o /usr/local/bin/kubectl && \
     chmod +x /usr/local/bin/kubectl && \
-    apk add git && \
     apk upgrade --no-cache && \
     # Cleanup uncessary files
-    rm /var/cache/apk/* && \
     rm -rf /tmp/*
 
 


### PR DESCRIPTION
**Why**
For running snowflake migrations on supernova deploys need suppport
for relative dates in date - this is provided by coreutils:
```
bash-5.0# date -d "last monday -7 days" +%Y-%m-%d
2021-03-29
```

Also put all the packages into one apk command instead of separate ones.
And deleted obsolete line to cleanup apk cache, since we are running apk
with --no-cache.

**Testing**
Tested locally