### PR TITLE
Add aws cli to build-harness

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,16 @@
 FROM alpine:3.12
 
 ARG KUBE_VERSION="v1.16.10"
+ENV AWS_DEFAULT_REGION us-west-1
+ENV AWSCLI_VERSION 1.14.50
 
 RUN apk add --no-cache --update bash ca-certificates openssh make gettext \
+    python3 py3-pip \
     docker which curl coreutils git && \
     update-ca-certificates && \
     curl -L https://storage.googleapis.com/kubernetes-release/release/${KUBE_VERSION}/bin/linux/amd64/kubectl -o /usr/local/bin/kubectl && \
     chmod +x /usr/local/bin/kubectl && \
+    pip3 install --upgrade pip && pip install awscli==${AWSCLI_VERSION} --upgrade && \
     apk upgrade --no-cache && \
     # Cleanup uncessary files
     rm -rf /tmp/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM alpine:3.12
 
 ARG KUBE_VERSION="v1.16.10"
-ENV AWS_DEFAULT_REGION us-west-1
-ENV AWSCLI_VERSION 1.14.50
+ENV AWS_DEFAULT_REGION us-west-2
+ENV AWSCLI_VERSION 1.19.107
 
 RUN apk add --no-cache --update bash ca-certificates openssh make gettext \
     python3 py3-pip \


### PR DESCRIPTION
**Why**
Needed for agent-desktop widget deployments.

Currently part of release-harness, but will move here/upstream.

**Testing**
widgets deployed on master