### PR TITLE
Upgrade Alpine, kubectl, awscli

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM alpine:3.15
 
-ARG KUBE_VERSION="v1.16.10"
+ARG KUBE_VERSION="v1.23.4"
 ENV AWS_DEFAULT_REGION us-west-2
-ENV AWSCLI_VERSION 1.19.107
+ENV AWSCLI_VERSION 1.22.73
 
 RUN apk add --no-cache --update bash ca-certificates openssh make gettext \
     python3 py3-pip \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.12
+FROM alpine:3.15
 
 ARG KUBE_VERSION="v1.16.10"
 ENV AWS_DEFAULT_REGION us-west-2


### PR DESCRIPTION
Upgrading to the current Alpine release so our `apk` commands can install the most recent and secure version of packages

Also upgrade kubectl and awscli to latest

### Testing
Will cut a release of this repo, and bump the version here: https://github.com/sagansystems/release-harness/blob/master/Dockerfile

Then run an AD build to see if it can deploy correctly