### PR TITLE
add support for kubernetes dry run mode to build-harness

### DIFF
--- a/modules/Makefile.kubernetes
+++ b/modules/Makefile.kubernetes
@@ -19,6 +19,24 @@ export SERIAL
 # Specify DEBUG=/dev/stderr to get useful output to stderr
 DEBUG ?= /dev/null
 
+# Dry run support - check for DRY_RUN or DRYRUN environment variables
+# Supports truthy values: True|true|1|YES|yes|Y|y
+ifneq ($(DRY_RUN),)
+  ifeq ($(shell echo "$(DRY_RUN)" | grep -E '^(True|true|1|YES|yes|Y|y)$$'),$(DRY_RUN))
+    KUBECTL_DRY_RUN_FLAG := --dry-run=server
+  else
+    KUBECTL_DRY_RUN_FLAG :=
+  endif
+else ifneq ($(DRYRUN),)
+  ifeq ($(shell echo "$(DRYRUN)" | grep -E '^(True|true|1|YES|yes|Y|y)$$'),$(DRYRUN))
+    KUBECTL_DRY_RUN_FLAG := --dry-run=server
+  else
+    KUBECTL_DRY_RUN_FLAG :=
+  endif
+else
+  KUBECTL_DRY_RUN_FLAG :=
+endif
+
 define envsubst
 	# Optionally load parameters for the kubernetes resources
 	set -a; \
@@ -55,7 +73,7 @@ endif
 
 SSH_PROXY_OPTIONS := -i ~/.tsh/keys/portal.$(CLUSTER)/$(OKTA_USER) -o ProxyCommand='ssh -p 3023 -i ~/.tsh/keys/portal.$(CLUSTER)/$(OKTA_USER) $(KUBECTL_SSH_USER)@portal.$(CLUSTER) -s proxy:bastion.$(CLUSTER):3022' portal.$(CLUSTER)
 
-KUBECTL_CMD ?= "$(KUBECTL)" --logtostderr=true --insecure-skip-tls-verify=true
+KUBECTL_CMD ?= "$(KUBECTL)" --logtostderr=true --insecure-skip-tls-verify=true $(KUBECTL_DRY_RUN_FLAG)
 
 ## Display info about the kubernetes setup
 kubernetes\:info:


### PR DESCRIPTION
Story details: https://app.shortcut.com/gladly/story/216515

## What

- Add support for dry run mode to the kubernetes commands

## Why

During migration away from Codefresh it will be helpful to be able to run the deploy job in Dry Run mode
Also, in Dry Run mode deploy.sh will output the kubernetes manifests, so this might be helpful for debugging

How to enable dry run mode: set `DRY_RUN=true` some legacy flows may set `DRYRUN=Y` which is also accepted

## Testing

Execute a codfresh pipeline that uses this module (agent-dekstop/datasets for instance) and ensure success